### PR TITLE
fix deprecated decorator for classmethods and staticmethods

### DIFF
--- a/monty/dev.py
+++ b/monty/dev.py
@@ -40,8 +40,12 @@ def deprecated(replacement=None, message=None):
         def wrapped(*args, **kwargs):
             msg = "%s is deprecated" % old.__name__
             if replacement is not None:
-                r = replacement.fget if isinstance(replacement, property) \
-                    else replacement
+                if isinstance(replacement, property):
+                    r = replacement.fget
+                elif isinstance(replacement, (classmethod, staticmethod)):
+                    r = replacement.__func__
+                else:
+                    r = replacement
                 msg += "; use %s in %s instead." % (r.__name__, r.__module__)
             if message is not None:
                 msg += "\n" + message

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -79,6 +79,29 @@ class DecoratorTest(unittest.TestCase):
             # Verify some things
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
+    def test_deprecated_classmethod(self):
+
+        class a(object):
+            def __init__(self):
+                pass
+
+            @classmethod
+            def classmethod_a(self):
+                pass
+
+            @classmethod
+            @deprecated(classmethod_a)
+            def classmethod_b(self):
+                return 'b'
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            # Trigger a warning.
+            self.assertEqual(a().classmethod_b(), 'b')
+            # Verify some things
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
     def test_requires(self):
 
         try:


### PR DESCRIPTION
Note that the same problem is present whenever the replacement function is decorated with a descriptor. This should take care just of the common case of classmethod and staticmethod. 