### PR TITLE
add makedirs_p

### DIFF
--- a/monty/os/__init__.py
+++ b/monty/os/__init__.py
@@ -8,6 +8,7 @@ __email__ = 'ongsp@ucsd.edu'
 __date__ = '1/24/14'
 
 import os
+import errno
 
 from contextlib import contextmanager
 
@@ -31,3 +32,22 @@ def cd(path):
         yield
     finally:
         os.chdir(cwd)
+
+
+def makedirs_p(path, **kwargs):
+    """
+    Wrapper for os.makedirs that does not raise an exception if the directory already exists, in the fashion of
+    "mkdir -p" command. The check is performed in a thread-safe way
+
+    Args:
+        path: path of the directory to create
+        kwargs: standard kwargs for os.makedirs
+    """
+
+    try:
+        os.makedirs(path, **kwargs)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -10,7 +10,7 @@ import unittest
 import os
 
 from monty.os.path import which, zpath
-from monty.os import cd
+from monty.os import cd, makedirs_p
 
 test_dir = os.path.join(os.path.dirname(__file__), 'test_files')
 
@@ -40,6 +40,21 @@ class CdTest(unittest.TestCase):
         except:
             pass
         self.assertFalse(os.path.exists("empty_file.txt"))
+
+
+class Makedirs_pTest(unittest.TestCase):
+
+    def setUp(self):
+        self.test_dir_path = os.path.join(test_dir, "test_dir")
+
+    def test_makedirs_p(self):
+        makedirs_p(self.test_dir_path)
+        self.assertTrue(os.path.exists(self.test_dir_path))
+        makedirs_p(self.test_dir_path)
+        self.assertRaises(OSError, makedirs_p, os.path.join(test_dir, "myfile_txt"))
+
+    def tearDown(self):
+        os.rmdir(self.test_dir_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adding a wrapper for os.makedirs that does not raise an exception if the directory already exists, in the fashion of "mkdir -p" command