### PR TITLE
jsanitize(<long>) should be <long>, not a <str>

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -228,7 +228,7 @@ def jsanitize(obj, strict=False, allow_bson=False):
     elif isinstance(obj, dict):
         return {k.__str__(): jsanitize(v, strict=strict, allow_bson=allow_bson)
                 for k, v in obj.items()}
-    elif isinstance(obj, (int, float)):
+    elif isinstance(obj, (int, float, long)):
         return obj
     elif obj is None:
         return None

--- a/monty/json.py
+++ b/monty/json.py
@@ -228,7 +228,7 @@ def jsanitize(obj, strict=False, allow_bson=False):
     elif isinstance(obj, dict):
         return {k.__str__(): jsanitize(v, strict=strict, allow_bson=allow_bson)
                 for k, v in obj.items()}
-    elif isinstance(obj, (int, float, long)):
+    elif isinstance(obj, six.integer_types + tuple([float])):
         return obj
     elif obj is None:
         return None


### PR DESCRIPTION
## Summary

In Javascript, there is a single Number type for all of (int, float, long) -- i.e. `json.dumps` properly handles `long`s, so let `long`s pass as is. Furthermore, MongoDB recognizes the `long` type.
