### PR TITLE
Preserve metadata in gzip_dir

### DIFF
--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -53,13 +53,14 @@ def gzip_dir(path, compresslevel=6):
             GzipFile, 6 is default for gzip.
     """
     for f in os.listdir(path):
+        full_f = os.path.join(path, f)
         if not f.lower().endswith("gz"):
-            with open(f, 'rb') as f_in, \
-                GzipFile('{}.gz'.format(f), 'wb',
+            with open(full_f, 'rb') as f_in, \
+                GzipFile('{}.gz'.format(full_f), 'wb',
                          compresslevel=compresslevel) as f_out:
                 shutil.copyfileobj(f_in, f_out)
-            shutil.copystat(f,'{}.gz'.format(f))
-            os.remove(f)
+            shutil.copystat(full_f,'{}.gz'.format(full_f))
+            os.remove(full_f)
 
 
 def compress_file(filepath, compression="gz"):

--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -58,6 +58,7 @@ def gzip_dir(path, compresslevel=6):
                 GzipFile('{}.gz'.format(f), 'wb',
                          compresslevel=compresslevel) as f_out:
                 shutil.copyfileobj(f_in, f_out)
+            shutil.copystat(f,'{}.gz'.format(f))
             os.remove(f)
 
 

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -99,7 +99,7 @@ class GzipDirTest(unittest.TestCase):
         self.assertFalse((os.path.exists(full_f)))
 
         with GzipFile("{}.gz".format(full_f)) as g:
-            self.assertEquals(g.readline(),u"what")
+            self.assertEquals(g.readline(),"what")
 
         self.assertAlmostEqual(os.path.getmtime("{}.gz".format(full_f)),self.mtime)
 

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -9,10 +9,11 @@ __date__ = '1/24/14'
 import unittest
 import os
 import shutil
+from gzip import GzipFile
 from io import open
 
 from monty.shutil import copy_r, compress_file, decompress_file, \
-    compress_dir, decompress_dir
+    compress_dir, decompress_dir, gzip_dir
 
 test_dir = os.path.join(os.path.dirname(__file__), 'test_files')
 
@@ -80,6 +81,30 @@ class CompressFileDirTest(unittest.TestCase):
 
     def tearDown(self):
         os.remove(os.path.join(test_dir, "tempfile"))
+
+class GzipDirTest(unittest.TestCase):
+
+    def setUp(self):
+        os.mkdir(os.path.join(test_dir, "gzip_dir"))
+        with open(os.path.join(test_dir, "gzip_dir", "tempfile"), "w") as f:
+            f.write(u"what")
+
+        self.mtime = os.path.getmtime(os.path.join(test_dir, "gzip_dir", "tempfile"))
+
+    def test_gzip(self):
+        full_f = os.path.join(test_dir, "gzip_dir", "tempfile")
+        gzip_dir(os.path.join(test_dir, "gzip_dir"))
+
+        self.assertTrue(os.path.exists("{}.gz".format(full_f)))
+        self.assertFalse((os.path.exists(full_f)))
+
+        with GzipFile("{}.gz".format(full_f)) as g:
+            self.assertEquals(g.readline(),u"what")
+
+        self.assertEquals(os.path.getmtime("{}.gz".format(full_f)),self.mtime)
+
+    def tearDown(self):
+        shutil.rmtree(os.path.join(test_dir, "gzip_dir"))
 
 
 if __name__ == "__main__":

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -101,7 +101,7 @@ class GzipDirTest(unittest.TestCase):
         with GzipFile("{}.gz".format(full_f)) as g:
             self.assertEquals(g.readline(),u"what")
 
-        self.assertEquals(os.path.getmtime("{}.gz".format(full_f)),self.mtime)
+        self.assertAlmostEqual(os.path.getmtime("{}.gz".format(full_f)),self.mtime)
 
     def tearDown(self):
         shutil.rmtree(os.path.join(test_dir, "gzip_dir"))


### PR DESCRIPTION
Copy the metadata over to the gzip'ed file using shutil copystat