### PR TITLE
Change out of the temp directory before deleting

### DIFF
--- a/monty/tempfile.py
+++ b/monty/tempfile.py
@@ -121,7 +121,9 @@ class ScratchDir(object):
                         pass
                 copy_r(".", self.cwd)
                 shutil.rmtree(tempdir)
-            shutil.rmtree(self.tempdir)
+                
             os.chdir(self.cwd)
+            shutil.rmtree(self.tempdir)
+            
             if self.create_symbolic_link:
                 os.remove(ScratchDir.SCR_LINK)


### PR DESCRIPTION
On Windows you get an error if calling shutil.rmtree(...) before os.chdir(...). If switching the order it works.
Linux can handle this.

## Summary

<Short few sentences, and summary of the major changes in bullet 
points>

* Feature 1
* Feature 2
* Fix 1
* Fix 2

## TODO

<If this is a work-in-progress, write something about what else needs to be 
done>

* Feature 1 supports a, but not b.