### PR TITLE
Allow binary in jsanitize for bson

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -258,7 +258,7 @@ def jsanitize(obj, strict=False, allow_bson=False):
     Returns:
         Sanitized dict that can be json serialized.
     """
-    if allow_bson and (isinstance(obj, datetime.datetime) or \
+    if allow_bson and (isinstance(obj, (datetime.datetime, bytes)) or \
                        (bson is not None and isinstance(obj,
                                                         bson.objectid.ObjectId))):
         return obj

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -151,5 +151,11 @@ class JsonTest(unittest.TestCase):
         self.assertEqual(clean["a"], ['b', [1, 2, 3]])
         self.assertIsInstance(clean["b"], six.string_types)
 
+        d = {"a": bytes([0, 1, 2])}
+        clean = jsanitize(d, allow_bson=True)
+        self.assertEqual(clean["a"], bytes([0, 1, 2]))
+        self.assertIsInstance(clean["a"], bytes)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -153,16 +153,11 @@ class JsonTest(unittest.TestCase):
         self.assertEqual(clean["a"], ['b', [1, 2, 3]])
         self.assertIsInstance(clean["b"], six.string_types)
 
-        d = {"a": six.binary_type([0, 1, 2])}
+        rnd_bin = six.binary_type(np.random.rand(10))
+        d = {"a": six.binary_type(rnd_bin)}
         clean = jsanitize(d, allow_bson=True)
-        self.assertEqual(clean["a"], six.binary_type([0, 1, 2]))
+        self.assertEqual(clean["a"], six.binary_type(rnd_bin))
         self.assertIsInstance(clean["a"], six.binary_type)
-
-        clean = jsanitize(d)
-        self.assertEqual(clean["a"], str(six.binary_type([0, 1, 2])))
-        self.assertEqual(literal_eval(clean["a"]), six.binary_type([0, 1, 2]))
-        self.assertIsInstance(clean["a"], str)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -13,7 +13,7 @@ import datetime
 import six
 from bson.objectid import ObjectId
 from ast import literal_eval
-from builtins import bytes, str
+
 
 from monty.json import MSONable, MontyEncoder, MontyDecoder, jsanitize
 
@@ -126,7 +126,7 @@ class JsonTest(unittest.TestCase):
         self.assertEqual(type(x), ObjectId)
 
     def test_jsanitize(self):
-        #clean_json should have no effect on None types.
+        # clean_json should have no effect on None types.
         d = {"hello": 1, "world": None}
         clean = jsanitize(d)
         self.assertIsNone(clean["world"])
@@ -153,15 +153,15 @@ class JsonTest(unittest.TestCase):
         self.assertEqual(clean["a"], ['b', [1, 2, 3]])
         self.assertIsInstance(clean["b"], six.string_types)
 
-        d = {"a": bytes([0, 1, 2])}
+        d = {"a": six.binary_type([0, 1, 2])}
         clean = jsanitize(d, allow_bson=True)
-        self.assertEqual(clean["a"], bytes([0, 1, 2]))
-        self.assertIsInstance(clean["a"], bytes)
+        self.assertEqual(clean["a"], six.binary_type([0, 1, 2]))
+        self.assertIsInstance(clean["a"], six.binary_type)
 
         clean = jsanitize(d)
-        self.assertEqual(clean["a"],str(bytes([0, 1, 2])))
-        self.assertEqual(literal_eval(clean["a"]),bytes([0, 1, 2]))
-        self.assertIsInstance(clean["a"],str)
+        self.assertEqual(clean["a"], str(six.binary_type([0, 1, 2])))
+        self.assertEqual(literal_eval(clean["a"]), six.binary_type([0, 1, 2]))
+        self.assertIsInstance(clean["a"], str)
 
 
 if __name__ == "__main__":

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -13,6 +13,7 @@ import datetime
 import six
 from bson.objectid import ObjectId
 from ast import literal_eval
+from builtins import bytes, str
 
 from monty.json import MSONable, MontyEncoder, MontyDecoder, jsanitize
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -12,6 +12,7 @@ import json
 import datetime
 import six
 from bson.objectid import ObjectId
+from ast import literal_eval
 
 from monty.json import MSONable, MontyEncoder, MontyDecoder, jsanitize
 
@@ -155,6 +156,11 @@ class JsonTest(unittest.TestCase):
         clean = jsanitize(d, allow_bson=True)
         self.assertEqual(clean["a"], bytes([0, 1, 2]))
         self.assertIsInstance(clean["a"], bytes)
+
+        clean = jsanitize(d)
+        self.assertEqual(clean["a"],str(bytes([0, 1, 2])))
+        self.assertEqual(literal_eval(clean["a"]),bytes([0, 1, 2]))
+        self.assertIsInstance(clean["a"],str)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Simple fix to allow binary data if allow_bson == True in jsanitize