### PR TITLE
Fix 'reverse_readfile' to account for bz2 files

### DIFF
--- a/monty/io.py
+++ b/monty/io.py
@@ -87,7 +87,7 @@ def reverse_readfile(filename):
     """
     try:
         with zopen(filename, "rb") as f:
-            if isinstance(f, gzip.GzipFile):
+            if isinstance(f, gzip.GzipFile) or isinstance(f, bz2.BZ2File):
                 for l in reversed(f.readlines()):
                     yield l.decode("utf-8").rstrip()
             else:


### PR DESCRIPTION
`monty.io.reverse_readfile` did not properly handle Bzip2 compressed files (only gzipped files) even though `zopen` accounts for both compression formats. I noticed this behavior when trying to parse zipped `OUTCAR` files with [pymatgen](https://github.com/materialsproject/pymatgen) where `Outcar("OUTCAR.gz")` works as expected whereas `Outcar("OUTCAR.bz2")` fails.