### PR TITLE
Fix RMTree Issues on some systems with ScratchDir

### DIFF
--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -131,3 +131,24 @@ def decompress_dir(path):
         for f in files:
             decompress_file(os.path.join(parent, f))
 
+
+def remove(path, follow_symlink=False):
+    """
+    Implements an remove function that will delete files, folder trees and symlink trees
+
+    1.) Remove a file
+    2.) Remove a symlink and follow into with a recursive rm if follow_symlink
+    3.) Remove directory with rmtree
+
+    Args:
+        path (str): path to remove
+        follow_symlink(bool): follow symlinks and removes whatever is in them
+    """
+    if os.path.isfile(path):
+        os.remove(path)
+    elif os.path.islink(path):
+        if follow_symlink:
+            remove(os.readlink(path))
+        os.unlink(path)
+    else:
+        shutil.rmtree(path)

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -108,6 +108,47 @@ class GzipDirTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(os.path.join(test_dir, "gzip_dir"))
 
+class RemoveTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp(dir=test_dir)
+        self.tempfile = tempfile.mkstemp(dir=self.tempdir)[1]
+
+        os.symlink(self.tempdir, os.path.join(test_dir, "temp_link"))
+        self.templink = os.path.join(test_dir, "temp_link")
+
+    def tearDown(self):
+        if os.path.isfile(self.tempfile):
+            os.remove(self.tempfile)
+
+        if os.path.islink(self.templink):
+            os.unlink(self.templink)
+
+        if os.path.isdir(self.tempdir):
+            shutil.rmtree(self.tempdir)
+
+    def test_remove_file(self):
+        print(os.listdir(test_dir))
+        remove(self.tempfile)
+        self.assertFalse(os.path.isfile(self.tempfile))
+
+    def test_remove_folder(self):
+        remove(self.tempdir)
+        self.assertFalse(os.path.isfile(self.tempfile))
+        self.assertFalse(os.path.isdir(self.tempdir))
+
+    def test_remove_symlink(self):
+        remove(self.templink)
+        self.assertTrue(os.path.isfile(self.tempfile))
+        self.assertTrue(os.path.isdir(self.tempdir))
+        self.assertFalse(os.path.islink(self.templink))
+
+    def test_remove_symlink_follow(self):
+        print(self.tempfile)
+        remove(self.templink, follow_symlink=True)
+        self.assertFalse(os.path.isfile(self.tempfile))
+        self.assertFalse(os.path.isdir(self.tempdir))
+        self.assertFalse(os.path.islink(self.templink))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -13,7 +13,7 @@ from gzip import GzipFile
 from io import open
 
 from monty.shutil import copy_r, compress_file, decompress_file, \
-    compress_dir, decompress_dir, gzip_dir
+    compress_dir, decompress_dir, gzip_dir, remove
 
 test_dir = os.path.join(os.path.dirname(__file__), 'test_files')
 

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -9,6 +9,7 @@ __date__ = '1/24/14'
 import unittest
 import os
 import shutil
+import tempfile
 from gzip import GzipFile
 from io import open
 


### PR DESCRIPTION
## Summary

ScratchDir seems to have some issues calling rmtree on symlinks on some systems. In order to alleviate this, I modified the algorithm for copy on exit and added a new remove method in monty.shutil to make the code a bit cleaner

* monty.shutil.remove will remove any file or folder and can follow symlinks
* ScratchDir copy on exit is a bit cleaner and easier to read