### PR TITLE
Fix for io.reverse_readline

### DIFF
--- a/monty/io.py
+++ b/monty/io.py
@@ -129,6 +129,9 @@ def reverse_readline(m_file, blk_size=4096, max_mem=4000000):
         file.readline() method, except the lines are returned from the back
         of the file.
     """
+    # Check if the file stream is a bit stream or not
+    is_text = isinstance(m_file, io.TextIOWrapper)
+
     try:
         file_size = os.path.getsize(m_file.name)
     except AttributeError:
@@ -150,7 +153,11 @@ def reverse_readline(m_file, blk_size=4096, max_mem=4000000):
 
         buf = ""
         m_file.seek(0, 2)
-        lastchar = m_file.read(1).decode("utf-8")
+        if is_text:
+            lastchar = m_file.read(1)
+        else:
+            lastchar = m_file.read(1).decode("utf-8")
+
         trailing_newline = (lastchar == "\n")
 
         while 1:
@@ -167,7 +174,10 @@ def reverse_readline(m_file, blk_size=4096, max_mem=4000000):
                 # Need to fill buffer
                 toread = min(blk_size, pos)
                 m_file.seek(pos - toread, 0)
-                buf = m_file.read(toread).decode("utf-8") + buf
+                if is_text:
+                    buf = m_file.read(toread) + buf
+                else:
+                    buf = m_file.read(toread).decode("utf-8") + buf
                 m_file.seek(pos - toread, 0)
                 if pos == toread:
                     buf = "\n" + buf

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -36,6 +36,19 @@ class ReverseReadlineTest(unittest.TestCase):
                                  "have read {}".format(
                                      int(line), self.NUMLINES - idx))
 
+    def test_reverse_readline_fake_big(self):
+        """
+        We are making sure a file containing line numbers is read in reverse
+        order, i.e. the first line that is read corresponds to the last line.
+        number
+        """
+        with open(os.path.join(test_dir, "3000_lines.txt")) as f:
+            for idx, line in enumerate(reverse_readline(f, max_mem=0)):
+                self.assertEqual(int(line), self.NUMLINES - idx,
+                                 "read_backwards read {} whereas it should "
+                                 "have read {}".format(
+                                     int(line), self.NUMLINES - idx))
+
     def test_reverse_readline_bz2(self):
         """
         We are making sure a file containing line numbers is read in reverse

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -38,9 +38,7 @@ class ReverseReadlineTest(unittest.TestCase):
 
     def test_reverse_readline_fake_big(self):
         """
-        We are making sure a file containing line numbers is read in reverse
-        order, i.e. the first line that is read corresponds to the last line.
-        number
+        Make sure that large textfiles are read properly
         """
         with open(os.path.join(test_dir, "3000_lines.txt")) as f:
             for idx, line in enumerate(reverse_readline(f, max_mem=0)):


### PR DESCRIPTION
## Fixed python3 incompatibility issue

- io.reverse_readline breaks on `m_file.read(1).decode("utf-8")` calls in python3
- added check to see if the file stream is a plain text stream
- added test which would give an error in older version