### PR TITLE
Use basename in determination of output/input type in monty serialization

### DIFF
--- a/monty/serialization.py
+++ b/monty/serialization.py
@@ -58,7 +58,7 @@ def loadfn(fn, *args, **kwargs):
     Returns:
         (object) Result of json/yaml/msgpack.load.
     """
-    if "mpk" in fn.lower():
+    if "mpk" in os.path.basename(fn).lower():
         if msgpack is None:
             raise RuntimeError(
                 "Loading of message pack files is not "
@@ -69,7 +69,7 @@ def loadfn(fn, *args, **kwargs):
             return msgpack.load(fp, *args, **kwargs)
     else:
         with zopen(fn) as fp:
-            if "yaml" in fn.lower():
+            if "yaml" in os.path.basename(fn).lower():
                 if yaml is None:
                     raise RuntimeError("Loading of YAML files is not "
                                        "possible as ruamel.yaml is not installed.")
@@ -98,7 +98,7 @@ def dumpfn(obj, fn, *args, **kwargs):
     Returns:
         (object) Result of json.load.
     """
-    if "mpk" in fn.lower():
+    if "mpk" in os.path.basename(fn).lower():
         if msgpack is None:
             raise RuntimeError(
                 "Loading of message pack files is not "
@@ -109,7 +109,7 @@ def dumpfn(obj, fn, *args, **kwargs):
             msgpack.dump(obj, fp, *args, **kwargs)
     else:
         with zopen(fn, "wt") as fp:
-            if "yaml" in fn.lower():
+            if "yaml" in os.path.basename(fn).lower():
                 if yaml is None:
                     raise RuntimeError("Loading of YAML files is not "
                                        "possible as ruamel.yaml is not installed.")

--- a/monty/serialization.py
+++ b/monty/serialization.py
@@ -5,6 +5,7 @@ and yaml.
 from __future__ import absolute_import, unicode_literals
 
 import json
+import os
 from monty.io import zopen
 from monty.json import MontyEncoder, MontyDecoder
 from monty.msgpack import default, object_hook

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -8,8 +8,10 @@ __date__ = '1/24/14'
 
 import unittest
 import os
+import json
 
 from monty.serialization import dumpfn, loadfn
+from monty.tempfile import ScratchDir
 
 
 class SerialTest(unittest.TestCase):
@@ -30,6 +32,16 @@ class SerialTest(unittest.TestCase):
         d2 = loadfn("monte_test.mpk")
         self.assertEqual(d, {k.decode('utf-8'): v.decode('utf-8') for k, v in d2.items()})
         os.remove("monte_test.mpk")
+
+        # Test to ensure basename is respected, and not directory
+        with ScratchDir('.'):
+            os.mkdir("mpk_test")
+            os.chdir("mpk_test")
+            fname = os.path.abspath("test_file.json")
+            dumpfn({"test": 1}, fname)
+            with open("test_file.json", "r") as f:
+                reloaded = json.loads(f.read())
+            self.assertEqual(reloaded['test'], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I encountered a somewhat weird error recently when using monty serialization in that temporary filenames generated by both standard library tempfile and monty's tempfile tools would occasionally have "mpk" in the absolute paths of filenames.  This would result in inconsistent (albeit somewhat rare) errors in integration tests when I was using temporary directories to test file output routines.  

Example:
```
dumpfn({"var_1": 1}, "tmp123MpK/output.json")
```

I dunno if it's really worth it, but this might be avoided by inferring the serialization format from a basename of the filename, rather than just the filename, which could include the path.