### PR TITLE
Unsafe hash

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -131,6 +131,39 @@ class MSONable(object):
         """
         return json.dumps(self, cls=MontyEncoder)
 
+    def unsafe_hash(self):
+        """
+        Returns an hash of the current object. This uses a generic but low
+        performance method of converting the object to a dictionary, flattening
+        any nested keys, and then performing a hash on the resulting object
+        """
+
+        def flatten(obj, seperator="."):
+            # Flattens a dictionary
+
+            flat_dict = {}
+            for key, value in obj.items():
+                if isinstance(value, dict):
+                    flat_dict.update(
+                        {
+                            seperator.join([key, _key]): _value
+                            for _key, _value in flatten(value).items()
+                        }
+                    )
+                elif isinstance(value, list):
+                    list_dict = {
+                        f"{key}{seperator}{num}": item for num, item in enumerate(value)
+                    }
+                    flat_dict.update(flatten(list_dict))
+                else:
+                    flat_dict[key] = value
+
+            return flat_dict
+
+        ordered_keys = sorted(flatten(jsanitize(self.as_dict())).items(), key=lambda x: x[0])
+        ordered_keys = [item for item in ordered_keys if "@" not in item[0]]
+        return sha1(json.dumps(OrderedDict(ordered_keys)).encode("utf-8"))
+
 
 class MontyEncoder(json.JSONEncoder):
     """

--- a/monty/json.py
+++ b/monty/json.py
@@ -9,6 +9,9 @@ import datetime
 import six
 import inspect
 
+from hashlib import sha1
+from collections import OrderedDict
+
 try:
     from importlib import import_module
 except ImportError:

--- a/monty/json.py
+++ b/monty/json.py
@@ -155,7 +155,7 @@ class MSONable(object):
                     )
                 elif isinstance(value, list):
                     list_dict = {
-                        f"{key}{seperator}{num}": item for num, item in enumerate(value)
+                        "{}{}{}".format(key,seperator,num): item for num, item in enumerate(value)
                     }
                     flat_dict.update(flatten(list_dict))
                 else:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -99,6 +99,42 @@ class MSONableTest(unittest.TestCase):
         d = obj.as_dict()
         objd = self.auto_mson.from_dict(d)
 
+    def test_unsafe_hash(self):
+        GMC = GoodMSONClass
+        a_list = [GMC(1, 1.0, "one"), GMC(2, 2.0, "two")]
+        b_dict = {"first": GMC(3, 3.0, "three"), "second": GMC(4, 4.0, "four")}
+        c_list_dict_list = [
+            {
+                "list1": [
+                    GMC(5, 5.0, "five"),
+                    GMC(6, 6.0, "six"),
+                    GMC(7, 7.0, "seven"),
+                ],
+                "list2": [GMC(8, 8.0, "eight")],
+            },
+            {
+                "list3": [
+                    GMC(9, 9.0, "nine"),
+                    GMC(10, 10.0, "ten"),
+                    GMC(11, 11.0, "eleven"),
+                    GMC(12, 12.0, "twelve"),
+                ],
+                "list4": [GMC(13, 13.0, "thirteen"), GMC(14, 14.0, "fourteen")],
+                "list5": [GMC(15, 15.0, "fifteen")],
+            },
+        ]
+        obj = GoodNestedMSONClass(
+            a_list=a_list, b_dict=b_dict, c_list_dict_list=c_list_dict_list
+        )
+
+        self.assertEqual(
+            a_list[0].unsafe_hash().hexdigest(),
+            "ea44de0e2ef627be582282c02c48e94de0d58ec6",
+        )
+        self.assertEqual(
+            obj.unsafe_hash().hexdigest(), "44204c8da394e878f7562c9aa2e37c2177f28b81"
+        )
+
     def test_version(self):
         obj = self.good_cls("Hello", "World", "Python")
         d = obj.as_dict()


### PR DESCRIPTION
## Summary

Adds a simple hashing function for all MSONable objects. Currently not implementing ___hash__ to prevent changing expected behavior of most MSONable objects. This is also not guaranteed to be very performant but expected to be very useful for DB search.
