### PR TITLE
Updates to dumpfn/loadfn

### DIFF
--- a/monty/serialization.py
+++ b/monty/serialization.py
@@ -47,9 +47,11 @@ __date__ = '7/29/14'
 def loadfn(fn, *args, **kwargs):
     """
     Loads json/yaml/msgpack directly from a filename instead of a
-    File-like object. For YAML, ruamel.yaml must be installed. The file type is
-    automatically detected. YAML is assumed if the filename contains "yaml"
-    (lower or upper case). Otherwise, json is always assumed.
+    File-like object. File may also be a BZ2 (".BZ2") or GZIP (".GZ", ".Z") compressed file.
+    For YAML, ruamel.yaml must be installed. The file type is automatically detected
+    from the file extension (case insensitive). YAML is assumed if the filename contains
+    ".yaml" or ".yml". Msgpack is assumed if the filename contains ".mpk".
+    JSON is otherwise assumed.
 
     Args:
         fn (str/Path): filename or pathlib.Path.
@@ -59,7 +61,7 @@ def loadfn(fn, *args, **kwargs):
     Returns:
         (object) Result of json/yaml/msgpack.load.
     """
-    if "mpk" in os.path.basename(fn).lower():
+    if ".mpk" in os.path.basename(fn).lower():
         if msgpack is None:
             raise RuntimeError(
                 "Loading of message pack files is not "
@@ -70,7 +72,8 @@ def loadfn(fn, *args, **kwargs):
             return msgpack.load(fp, *args, **kwargs)
     else:
         with zopen(fn) as fp:
-            if "yaml" in os.path.basename(fn).lower():
+            if any(ext in os.path.basename(fn).lower()
+                   for ext in (".yaml", ".yml")):
                 if yaml is None:
                     raise RuntimeError("Loading of YAML files is not "
                                        "possible as ruamel.yaml is not installed.")
@@ -85,10 +88,12 @@ def loadfn(fn, *args, **kwargs):
 
 def dumpfn(obj, fn, *args, **kwargs):
     """
-    Dump to a json/yaml directly by filename instead of a File-like object.
-    For YAML, ruamel.yaml must be installed. The file type is automatically
-    detected. YAML is assumed if the filename contains "yaml" (lower or upper
-    case). Otherwise, json is always assumed.
+    Dump to a json/yaml directly by filename instead of a
+    File-like object. File may also be a BZ2 (".BZ2") or GZIP (".GZ", ".Z") compressed file.
+    For YAML, ruamel.yaml must be installed. The file type is automatically detected
+    from the file extension (case insensitive). YAML is assumed if the filename contains
+    ".yaml" or ".yml". Msgpack is assumed if the filename contains ".mpk".
+    JSON is otherwise assumed.
 
     Args:
         obj (object): Object to dump.
@@ -99,7 +104,7 @@ def dumpfn(obj, fn, *args, **kwargs):
     Returns:
         (object) Result of json.load.
     """
-    if "mpk" in os.path.basename(fn).lower():
+    if ".mpk" in os.path.basename(fn).lower():
         if msgpack is None:
             raise RuntimeError(
                 "Loading of message pack files is not "
@@ -110,7 +115,8 @@ def dumpfn(obj, fn, *args, **kwargs):
             msgpack.dump(obj, fp, *args, **kwargs)
     else:
         with zopen(fn, "wt") as fp:
-            if "yaml" in os.path.basename(fn).lower():
+            if any(ext in os.path.basename(fn).lower()
+                   for ext in (".yaml", ".yml")):
                 if yaml is None:
                     raise RuntimeError("Loading of YAML files is not "
                                        "possible as ruamel.yaml is not installed.")

--- a/monty/serialization.py
+++ b/monty/serialization.py
@@ -44,24 +44,36 @@ __email__ = 'ongsp@ucsd.edu'
 __date__ = '7/29/14'
 
 
-def loadfn(fn, *args, **kwargs):
+def loadfn(fn, *args, fmt=None, **kwargs):
     """
     Loads json/yaml/msgpack directly from a filename instead of a
     File-like object. File may also be a BZ2 (".BZ2") or GZIP (".GZ", ".Z") compressed file.
     For YAML, ruamel.yaml must be installed. The file type is automatically detected
     from the file extension (case insensitive). YAML is assumed if the filename contains
     ".yaml" or ".yml". Msgpack is assumed if the filename contains ".mpk".
-    JSON is otherwise assumed.
+    JSON is otherwise assumed. The file type can be specified manually with "fmt='type'".
 
     Args:
         fn (str/Path): filename or pathlib.Path.
         \*args: Any of the args supported by json/yaml.load.
+        fmt (str): manually specify file format to read.
+            Options are "json", "yaml", or "mpk". If None, the
+            file type will be detected automatically.
         \*\*kwargs: Any of the kwargs supported by json/yaml.load.
 
     Returns:
         (object) Result of json/yaml/msgpack.load.
     """
-    if ".mpk" in os.path.basename(fn).lower():
+    if not fmt:
+        basename = os.path.basename(fn).lower()
+        if ".mpk" in basename:
+            fmt = 'mpk'
+        elif any(ext in basename for ext in (".yaml", ".yml")):
+            fmt = 'yaml'
+        else:
+            fmt = 'json'
+
+    if fmt == 'mpk':
         if msgpack is None:
             raise RuntimeError(
                 "Loading of message pack files is not "
@@ -72,39 +84,52 @@ def loadfn(fn, *args, **kwargs):
             return msgpack.load(fp, *args, **kwargs)
     else:
         with zopen(fn, 'rt') as fp:
-            if any(ext in os.path.basename(fn).lower()
-                   for ext in (".yaml", ".yml")):
+            if fmt == 'yaml':
                 if yaml is None:
                     raise RuntimeError("Loading of YAML files is not "
                                        "possible as ruamel.yaml is not installed.")
                 if "Loader" not in kwargs:
                     kwargs["Loader"] = Loader
                 return yaml.load(fp, *args, **kwargs)
-            else:
+            elif fmt == 'json':
                 if "cls" not in kwargs:
                     kwargs["cls"] = MontyDecoder
                 return json.load(fp, *args, **kwargs)
+            else:
+                raise TypeError("Invalid format: {}".format(fmt))
 
 
-def dumpfn(obj, fn, *args, **kwargs):
+def dumpfn(obj, fn, *args, fmt=None, **kwargs):
     """
     Dump to a json/yaml directly by filename instead of a
     File-like object. File may also be a BZ2 (".BZ2") or GZIP (".GZ", ".Z") compressed file.
     For YAML, ruamel.yaml must be installed. The file type is automatically detected
     from the file extension (case insensitive). YAML is assumed if the filename contains
     ".yaml" or ".yml". Msgpack is assumed if the filename contains ".mpk".
-    JSON is otherwise assumed.
+    JSON is otherwise assumed. The file type can be specified manually with "fmt='type'".
 
     Args:
         obj (object): Object to dump.
         fn (str/Path): filename or pathlib.Path.
         \*args: Any of the args supported by json/yaml.dump.
+        fmt (str): manually specify file format to read.
+            Options are "json", "yaml", or "mpk". If None, the
+            file type will be detected automatically.
         \*\*kwargs: Any of the kwargs supported by json/yaml.dump.
 
     Returns:
         (object) Result of json.load.
     """
-    if ".mpk" in os.path.basename(fn).lower():
+    if not fmt:
+        basename = os.path.basename(fn).lower()
+        if ".mpk" in basename:
+            fmt = 'mpk'
+        elif any(ext in basename for ext in (".yaml", ".yml")):
+            fmt = 'yaml'
+        else:
+            fmt = 'json'
+
+    if fmt == 'mpk':
         if msgpack is None:
             raise RuntimeError(
                 "Loading of message pack files is not "
@@ -115,15 +140,16 @@ def dumpfn(obj, fn, *args, **kwargs):
             msgpack.dump(obj, fp, *args, **kwargs)
     else:
         with zopen(fn, "wt") as fp:
-            if any(ext in os.path.basename(fn).lower()
-                   for ext in (".yaml", ".yml")):
+            if fmt == 'yaml':
                 if yaml is None:
                     raise RuntimeError("Loading of YAML files is not "
                                        "possible as ruamel.yaml is not installed.")
                 if "Dumper" not in kwargs:
                     kwargs["Dumper"] = Dumper
                 yaml.dump(obj, fp, *args, **kwargs)
-            else:
+            elif fmt == 'json':
                 if "cls" not in kwargs:
                     kwargs["cls"] = MontyEncoder
                 fp.write("%s" % json.dumps(obj, *args, **kwargs))
+            else:
+                raise TypeError("Invalid format: {}".format(fmt))

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -9,6 +9,7 @@ __date__ = '1/24/14'
 import unittest
 import os
 import json
+import glob
 try:
     import msgpack
 except ImportError:
@@ -19,9 +20,26 @@ from monty.tempfile import ScratchDir
 
 
 class SerialTest(unittest.TestCase):
+    @classmethod
+    def tearDownClass(cls):
+        # Cleans up test files if a test fails
+        files_to_clean_up = glob.glob('monte_test.*')
+        for fn in files_to_clean_up:
+            os.remove(fn)
 
     def test_dumpfn_loadfn(self):
         d = {"hello": "world"}
+
+        # Test standard configuration
+        for ext in ("json", "yaml", "yml", "json.gz", "yaml.gz", "json.bz2", "yaml.bz2"):
+            fn = "monte_test.{}".format(ext)
+            dumpfn(d, fn)
+            d2 = loadfn(fn)
+            self.assertEqual(d, d2,
+                             msg="Test file with extension {} did not parse correctly".format(ext))
+            os.remove(fn)
+
+        # Test custom kwarg configuration
         dumpfn(d, "monte_test.json", indent=4)
         d2 = loadfn("monte_test.json")
         self.assertEqual(d, d2)
@@ -29,8 +47,6 @@ class SerialTest(unittest.TestCase):
         dumpfn(d, "monte_test.yaml", default_flow_style=False)
         d2 = loadfn("monte_test.yaml")
         self.assertEqual(d, d2)
-        dumpfn(d, "monte_test.yaml")
-        d2 = loadfn("monte_test.yaml")
         os.remove("monte_test.yaml")
 
     @unittest.skipIf(msgpack is None, "msgpack-python not installed.")

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -49,14 +49,37 @@ class SerialTest(unittest.TestCase):
         self.assertEqual(d, d2)
         os.remove("monte_test.yaml")
 
+        # Test manual formatting specification
+        for fmt in ("json", "yaml"):
+            fn = "monte_test.txt"
+            dumpfn(d, fn, fmt=fmt)
+            d2 = loadfn(fn, fmt=fmt)
+            self.assertEqual(d, d2,
+                             msg="Test file with extension {} did not parse correctly".format(ext))
+            os.remove(fn)
+
+        with self.assertRaises(TypeError):
+            dumpfn(d, 'monte_test.txt', fmt='garbage')
+        with self.assertRaises(TypeError):
+            loadfn('monte_test.txt', fmt='garbage')
+
     @unittest.skipIf(msgpack is None, "msgpack-python not installed.")
     def test_mpk(self):
         d = {"hello": "world"}
+
+        # Test automatic format detection
         dumpfn(d, "monte_test.mpk")
         d2 = loadfn("monte_test.mpk")
         self.assertEqual(d, {k.decode('utf-8'): v.decode('utf-8')
                              for k, v in d2.items()})
         os.remove("monte_test.mpk")
+
+        # Test manual format specification
+        dumpfn(d, "monte_test.bin", fmt='mpk')
+        d2 = loadfn("monte_test.bin", fmt='mpk')
+        self.assertEqual(d, {k.decode('utf-8'): v.decode('utf-8')
+                             for k, v in d2.items()})
+        os.remove("monte_test.bin")
 
         # Test to ensure basename is respected, and not directory
         with ScratchDir('.'):


### PR DESCRIPTION
## Summary

This PR adds support for "yml" as an extension for YAML files in `loadfn` and `dumpfn`. The PR also changes the logic for determining file type in these functions by requiring that the extensions be preceded by a period character to match the appropriate file type (i.e. ".mpk", ".yaml", ".yml"), because "yml" may come up in the file name outside of the extension.

Tests caught a bug when opening json files stored as gzip with python<3.6. The default read format used by `zopen` is binary, and `json.loads()` does not support binary strings until python 3.6. So, the PR now explicitly sets read mode to text (`'rt'`).

Tests have been expanded to verify these functions work with the file extensions/types and documentation has been updated.

Per a discussion with colleagues, I thought it might be useful to have a keyword argument to manually select the file format like: `dumpfn(obj, 'somefile.txt', fmt='yaml')`. Would have to check the kwargs for json/yaml/msgpack.load to make sure there are no clashes. Thoughts? (I have included this as the last commit, but can revert if objectionable.)

* Add support for YAML files with ".yml" extension in `dumpfn`/`loadfn`
* Tweak file format determination logic in `dumpfn`/`loadfn` to require a period before the extension
* Add manual format specification through `fmt` kwarg to `dumpfn`/`loadfn`

## TODO

* Update changelog (is this done manually in the rst file?)