### PR TITLE
Fix GZip not crawling sub-directories

### DIFF
--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -3,7 +3,6 @@ Copying and zipping utilities. Works on directories mostly.
 """
 
 import os
-import glob
 import shutil
 import warnings
 from gzip import GzipFile
@@ -51,14 +50,16 @@ def gzip_dir(path, compresslevel=6):
         compresslevel (int): Level of compression, 1-9. 9 is default for
             GzipFile, 6 is default for gzip.
     """
-    for f in glob.glob("{}/**".format(path), recursive=True):
-        if not f.lower().endswith("gz") and not os.path.isdir(f):
-            with open(f, 'rb') as f_in, \
-                    GzipFile('{}.gz'.format(f), 'wb',
-                             compresslevel=compresslevel) as f_out:
-                shutil.copyfileobj(f_in, f_out)
-            shutil.copystat(f, '{}.gz'.format(f))
-            os.remove(f)
+    for root, _, files in os.walk(path):
+        for f in files:
+            full_f = os.path.abspath(os.path.join(root, f))
+            if not f.lower().endswith("gz") and not os.path.isdir(full_f):
+                with open(full_f, "rb") as f_in, GzipFile(
+                    "{}.gz".format(full_f), "wb", compresslevel=compresslevel
+                ) as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+                shutil.copystat(full_f, "{}.gz".format(full_f))
+                os.remove(full_f)
 
 
 def compress_file(filepath, compression="gz"):

--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -3,6 +3,7 @@ Copying and zipping utilities. Works on directories mostly.
 """
 
 import os
+import glob
 import shutil
 import warnings
 from gzip import GzipFile
@@ -50,15 +51,14 @@ def gzip_dir(path, compresslevel=6):
         compresslevel (int): Level of compression, 1-9. 9 is default for
             GzipFile, 6 is default for gzip.
     """
-    for f in os.listdir(path):
-        full_f = os.path.join(path, f)
-        if not f.lower().endswith("gz"):
-            with open(full_f, 'rb') as f_in, \
-                    GzipFile('{}.gz'.format(full_f), 'wb',
+    for f in glob.glob("{}/**".format(path),recursive=True):
+        if not f.lower().endswith("gz") and not os.path.isdir(f):
+            with open(f, 'rb') as f_in, \
+                    GzipFile('{}.gz'.format(f), 'wb',
                              compresslevel=compresslevel) as f_out:
                 shutil.copyfileobj(f_in, f_out)
-            shutil.copystat(full_f, '{}.gz'.format(full_f))
-            os.remove(full_f)
+            shutil.copystat(f, '{}.gz'.format(f))
+            os.remove(f)
 
 
 def compress_file(filepath, compression="gz"):

--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -51,7 +51,7 @@ def gzip_dir(path, compresslevel=6):
         compresslevel (int): Level of compression, 1-9. 9 is default for
             GzipFile, 6 is default for gzip.
     """
-    for f in glob.glob("{}/**".format(path),recursive=True):
+    for f in glob.glob("{}/**".format(path), recursive=True):
         if not f.lower().endswith("gz") and not os.path.isdir(f):
             with open(f, 'rb') as f_in, \
                     GzipFile('{}.gz'.format(f), 'wb',

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -98,6 +98,21 @@ class GzipDirTest(unittest.TestCase):
 
         self.assertAlmostEqual(os.path.getmtime("{}.gz".format(full_f)),
                                self.mtime, 4)
+                               
+    def test_handle_sub_dirs(self):
+        sub_dir = os.path.join(test_dir,"gzip_dir","sub_dir")
+        sub_file = os.path.join(sub_dir,"new_tempfile")
+        os.mkdir(sub_dir)
+        with open(sub_file, "w") as f:
+            f.write(u"anotherwhat")
+
+        gzip_dir(os.path.join(test_dir, "gzip_dir"))
+
+        self.assertTrue(os.path.exists("{}.gz".format(sub_file)))
+        self.assertFalse((os.path.exists(sub_file)))
+
+        with GzipFile("{}.gz".format(sub_file)) as g:
+            self.assertEqual(g.readline().decode("utf-8"), "anotherwhat")
 
     def tearDown(self):
         shutil.rmtree(os.path.join(test_dir, "gzip_dir"))

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -98,10 +98,10 @@ class GzipDirTest(unittest.TestCase):
 
         self.assertAlmostEqual(os.path.getmtime("{}.gz".format(full_f)),
                                self.mtime, 4)
-                               
+
     def test_handle_sub_dirs(self):
-        sub_dir = os.path.join(test_dir,"gzip_dir","sub_dir")
-        sub_file = os.path.join(sub_dir,"new_tempfile")
+        sub_dir = os.path.join(test_dir, "gzip_dir", "sub_dir")
+        sub_file = os.path.join(sub_dir, "new_tempfile")
         os.mkdir(sub_dir)
         with open(sub_file, "w") as f:
             f.write(u"anotherwhat")


### PR DESCRIPTION
## Summary

`gzip_dirs` was having problems with sub-directories. It was trying to gzip them which causes an exception and fails. This updated method crawls the sub-directories and gzip's files in them.

I refrained from using `Pathlib` to preserve compatibility, but I think at some point `monty` should switch over as it is SO nice. 