### PR TITLE
travis: add all officially supported python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install: "pip install -r requirements-ci.txt"
 script:
   - pytest


### PR DESCRIPTION
## Summary

We saw tests break on python3.7. According to setup.py python3.7/python3.8 are officially supported and should be therefore also tested.

## TODO

-