### PR TITLE
Update test_serializaiton for latest msgpack

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -54,8 +54,7 @@ class SerialTest(unittest.TestCase):
         # Test automatic format detection
         dumpfn(d, "monte_test.mpk")
         d2 = loadfn("monte_test.mpk")
-        self.assertEqual(d, {k.decode('utf-8'): v.decode('utf-8')
-                             for k, v in d2.items()})
+        self.assertEqual(d, {k: v for k, v in d2.items()})
         os.remove("monte_test.mpk")
 
         # Test to ensure basename is respected, and not directory


### PR DESCRIPTION
msgpack>=1 returns a str, not bytes.

previous error:
```
    File "/build/source/tests/test_serialization.py", line 57, in <dictcomp>
      self.assertEqual(d, {k.decode('utf-8'): v.decode('utf-8')
  AttributeError: 'str' object has no attribute 'decode'
```