### PR TITLE
added support for np.array with complex dtype

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -103,19 +103,22 @@ class MSONable:
     old_module.old_class: new_module.new_class
     """
 
-    REDIRECT = _load_redirect(os.path.join(os.path.expanduser("~"),
-                                           ".monty.yaml"))
+    REDIRECT = _load_redirect(
+        os.path.join(os.path.expanduser("~"), ".monty.yaml"))
 
     def as_dict(self) -> dict:
         """
         A JSON serializable dict representation of an object.
         """
-        d = {"@module": self.__class__.__module__,
-             "@class": self.__class__.__name__}
+        d = {
+            "@module": self.__class__.__module__,
+            "@class": self.__class__.__name__
+        }
 
         try:
             parent_module = self.__class__.__module__.split('.')[0]
-            module_version = import_module(parent_module).__version__  # type: ignore
+            module_version = import_module(
+                parent_module).__version__  # type: ignore
             d["@version"] = u"{}".format(module_version)
         except (AttributeError, ImportError):
             d["@version"] = None  # type: ignore
@@ -163,8 +166,10 @@ class MSONable:
         :param d: Dict representation.
         :return: MSONable class.
         """
-        decoded = {k: MontyDecoder().process_decoded(v) for k, v in d.items()
-                   if not k.startswith("@")}
+        decoded = {
+            k: MontyDecoder().process_decoded(v)
+            for k, v in d.items() if not k.startswith("@")
+        }
         return cls(**decoded)
 
     def to_json(self) -> str:
@@ -186,12 +191,10 @@ class MSONable:
             flat_dict = {}
             for key, value in obj.items():
                 if isinstance(value, dict):
-                    flat_dict.update(
-                        {
-                            seperator.join([key, _key]): _value
-                            for _key, _value in flatten(value).items()
-                        }
-                    )
+                    flat_dict.update({
+                        seperator.join([key, _key]): _value
+                        for _key, _value in flatten(value).items()
+                    })
                 elif isinstance(value, list):
                     list_dict = {
                         "{}{}{}".format(key, seperator, num): item
@@ -235,21 +238,37 @@ class MontyEncoder(json.JSONEncoder):
             Python dict representation.
         """
         if isinstance(o, datetime.datetime):
-            return {"@module": "datetime", "@class": "datetime",
-                    "string": o.__str__()}
+            return {
+                "@module": "datetime",
+                "@class": "datetime",
+                "string": o.__str__()
+            }
         if np is not None:
             if isinstance(o, np.ndarray):
-                return {"@module": "numpy",
+                if str(o.dtype).startswith('complex'):
+                    return {
+                        "@module": "numpy",
                         "@class": "array",
                         "dtype": o.dtype.__str__(),
-                        "data": o.tolist()}
+                        "data": [o.real.tolist(),
+                                 o.imag.tolist()]
+                    }
+                else:
+                    return {
+                        "@module": "numpy",
+                        "@class": "array",
+                        "dtype": o.dtype.__str__(),
+                        "data": o.tolist()
+                    }
             if isinstance(o, np.generic):
                 return o.item()
         if bson is not None:
             if isinstance(o, bson.objectid.ObjectId):
-                return {"@module": "bson.objectid",
-                        "@class": "ObjectId",
-                        "oid": str(o)}
+                return {
+                    "@module": "bson.objectid",
+                    "@class": "ObjectId",
+                    "oid": str(o)
+                }
 
         try:
             d = o.as_dict()
@@ -260,7 +279,8 @@ class MontyEncoder(json.JSONEncoder):
             if "@version" not in d:
                 try:
                     parent_module = o.__class__.__module__.split('.')[0]
-                    module_version = import_module(parent_module).__version__  # type: ignore
+                    module_version = import_module(
+                        parent_module).__version__  # type: ignore
                     d["@version"] = u"{}".format(module_version)
                 except (AttributeError, ImportError):
                     d["@version"] = None
@@ -302,30 +322,39 @@ class MontyDecoder(json.JSONDecoder):
             if modname and modname not in ["bson.objectid", "numpy"]:
                 if modname == "datetime" and classname == "datetime":
                     try:
-                        dt = datetime.datetime.strptime(d["string"],
-                                                        "%Y-%m-%d %H:%M:%S.%f")
+                        dt = datetime.datetime.strptime(
+                            d["string"], "%Y-%m-%d %H:%M:%S.%f")
                     except ValueError:
-                        dt = datetime.datetime.strptime(d["string"],
-                                                        "%Y-%m-%d %H:%M:%S")
+                        dt = datetime.datetime.strptime(
+                            d["string"], "%Y-%m-%d %H:%M:%S")
                     return dt
 
                 mod = __import__(modname, globals(), locals(), [classname], 0)
                 if hasattr(mod, classname):
                     cls_ = getattr(mod, classname)
-                    data = {k: v for k, v in d.items()
-                            if not k.startswith("@")}
+                    data = {
+                        k: v
+                        for k, v in d.items() if not k.startswith("@")
+                    }
                     if hasattr(cls_, "from_dict"):
                         return cls_.from_dict(data)
             elif np is not None and modname == "numpy" and classname == \
                     "array":
-                return np.array(d["data"], dtype=d["dtype"])
+                if d["dtype"].startswith('complex'):
+                    return np.array([
+                        r + i * 1j for r, i in zip(*d["data"])],
+                        dtype=d["dtype"])
+                else:
+                    return np.array(d["data"], dtype=d["dtype"])
 
             elif (bson is not None) and modname == "bson.objectid" and \
                     classname == "ObjectId":
                 return bson.objectid.ObjectId(d["oid"])
 
-            return {self.process_decoded(k): self.process_decoded(v)
-                    for k, v in d.items()}
+            return {
+                self.process_decoded(k): self.process_decoded(v)
+                for k, v in d.items()
+            }
 
         if isinstance(d, list):
             return [self.process_decoded(x) for x in d]
@@ -373,17 +402,23 @@ def jsanitize(obj, strict=False, allow_bson=False):
         Sanitized dict that can be json serialized.
     """
     if allow_bson and (isinstance(obj, (datetime.datetime, bytes)) or
-                       (bson is not None and
-                        isinstance(obj, bson.objectid.ObjectId))):
+                       (bson is not None
+                        and isinstance(obj, bson.objectid.ObjectId))):
         return obj
     if isinstance(obj, (list, tuple)):
-        return [jsanitize(i, strict=strict, allow_bson=allow_bson) for i in obj]
+        return [
+            jsanitize(i, strict=strict, allow_bson=allow_bson) for i in obj
+        ]
     if np is not None and isinstance(obj, np.ndarray):
-        return [jsanitize(i, strict=strict, allow_bson=allow_bson) for i in
-                obj.tolist()]
+        return [
+            jsanitize(i, strict=strict, allow_bson=allow_bson)
+            for i in obj.tolist()
+        ]
     if isinstance(obj, dict):
-        return {k.__str__(): jsanitize(v, strict=strict, allow_bson=allow_bson)
-                for k, v in obj.items()}
+        return {
+            k.__str__(): jsanitize(v, strict=strict, allow_bson=allow_bson)
+            for k, v in obj.items()
+        }
     if isinstance(obj, (int, float)):
         return obj
     if obj is None:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -238,6 +238,18 @@ class JsonTest(unittest.TestCase):
         x = np.min([1, 2, 3]) > 2
         self.assertRaises(TypeError, json.dumps, x)
 
+        x = np.array([1+1j, 2+1j, 3+1j], dtype="complex64")
+        self.assertRaises(TypeError, json.dumps, x)
+        djson = json.dumps(x, cls=MontyEncoder)
+        d = json.loads(djson)
+        self.assertEqual(d["@class"], "array")
+        self.assertEqual(d["@module"], "numpy")
+        self.assertEqual(d["data"], [[1.0,2.0,3.0],[1.0,1.0,1.0]])
+        self.assertEqual(d["dtype"], "complex64")
+        x = json.loads(djson, cls=MontyDecoder)
+        self.assertEqual(type(x), np.ndarray)
+        self.assertEqual(x.dtype, "complex64")
+        
     def test_objectid(self):
         oid = ObjectId('562e8301218dcbbc3d7d91ce')
         self.assertRaises(TypeError, json.dumps, oid)


### PR DESCRIPTION
This is a suggestion about supporting the encoding/decoding 
np.arrays containing complex numbers which I found useful multiple times.

p.s. I run a yapf linting, that's why there are some cosmetics edits that can be skipped.