### PR TITLE
Feature: Add Varidac Args to MSONable

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -120,7 +120,8 @@ class MSONable:
         except (AttributeError, ImportError):
             d["@version"] = None  # type: ignore
 
-        args = getfullargspec(self.__class__.__init__).args
+        spec = getfullargspec(self.__class__.__init__)
+        args = spec.args
 
         def recursive_as_dict(obj):
             if isinstance(obj, (list, tuple)):
@@ -151,6 +152,8 @@ class MSONable:
         if hasattr(self, "kwargs"):
             # type: ignore
             d.update(**getattr(self, "kwargs"))  # pylint: disable=E1101
+        if spec.varargs is not None and getattr(self, spec.varargs, None) is not None:
+            d.update({spec.varargs: getattr(self, spec.varargs)})
         if hasattr(self, "_kwargs"):
             d.update(**getattr(self, "_kwargs"))  # pylint: disable=E1101
         if isinstance(self, Enum):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -17,17 +17,18 @@ test_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_files"
 
 class GoodMSONClass(MSONable):
 
-    def __init__(self, a, b, c, d=1, **kwargs):
+    def __init__(self, a, b, c, d=1, *values, **kwargs):
         self.a = a
         self.b = b
         self._c = c
         self._d = d
+        self.values = values
         self.kwargs = kwargs
 
     def __eq__(self, other):
         return (self.a == other.a and self.b == other.b and
                 self._c == other._c and self._d == other._d and
-                self.kwargs == other.kwargs)
+                self.kwargs == other.kwargs and self.values == other.values)
 
 
 class GoodNestedMSONClass(MSONable):
@@ -199,7 +200,7 @@ class JsonTest(unittest.TestCase):
         self.assertEqual(obj2.b, 2)
         self.assertEqual(obj2._c, 3)
         self.assertEqual(obj2._d, 1)
-        self.assertEqual(obj2.kwargs, {"hello": "world"})
+        self.assertEqual(obj2.kwargs, {"hello": "world", "values": []})
         obj = GoodMSONClass(obj, 2, 3)
         s = json.dumps(obj, cls=MontyEncoder)
         obj2 = json.loads(s, cls=MontyDecoder)


### PR DESCRIPTION
## Summary

This PR adds varidac argument support to Monty MSONable.