### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     description="Monty is the missing complement to Python.",
     long_description=long_desc,
     keywords=["monty"],
+    python_requires='>=3.5',
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",


### PR DESCRIPTION
## Summary
Indicate that monty is only compatible with Python versions 3.5 and later.

That python 3-only code was added to this project without this indicator was allowing pip to install python-3-only code in python 2 environments.  This is still a problem, as versions still exist in PYPI that are Python-3-only and which don't have this attribute, but better late than never.
