### PR TITLE
Fix MontyDecoder to decode nested complex ndarray

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -341,7 +341,8 @@ class MontyDecoder(json.JSONDecoder):
             elif np is not None and modname == "numpy" and classname == "array":
                 if d["dtype"].startswith('complex'):
                     return np.array([
-                        r + i * 1j for r, i in zip(*d["data"])], dtype=d["dtype"])
+                        np.array(r) + np.array(i) * 1j
+                        for r, i in zip(*d["data"])], dtype=d["dtype"])
                 return np.array(d["data"], dtype=d["dtype"])
 
             elif (bson is not None) and modname == "bson.objectid" and classname == "ObjectId":

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -250,7 +250,20 @@ class JsonTest(unittest.TestCase):
         x = json.loads(djson, cls=MontyDecoder)
         self.assertEqual(type(x), np.ndarray)
         self.assertEqual(x.dtype, "complex64")
-        
+
+        x = np.array([[1+1j, 2+1j], [3+1j, 4+1j]], dtype="complex64")
+        self.assertRaises(TypeError, json.dumps, x)
+        djson = json.dumps(x, cls=MontyEncoder)
+        d = json.loads(djson)
+        self.assertEqual(d["@class"], "array")
+        self.assertEqual(d["@module"], "numpy")
+        self.assertEqual(d["data"], [[[1.0, 2.0], [3.0, 4.0]],
+                                     [[1.0, 1.0], [1.0, 1.0]]])
+        self.assertEqual(d["dtype"], "complex64")
+        x = json.loads(djson, cls=MontyDecoder)
+        self.assertEqual(type(x), np.ndarray)
+        self.assertEqual(x.dtype, "complex64")
+
     def test_objectid(self):
         oid = ObjectId('562e8301218dcbbc3d7d91ce')
         self.assertRaises(TypeError, json.dumps, oid)


### PR DESCRIPTION
## Summary

I fixed the issue where the nested complex numpy array were not be decoded by MontyDecoder.
