### PR TITLE
Update pydantic schema to refer enum instead of const

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -230,8 +230,8 @@ class MSONable:
             {
                 "type": "object",
                 "properties": {
-                    "@class": {"const": cls.__name__},
-                    "@module": {"const": cls.__module__},
+                    "@class": {"enum": [cls.__name__], "type": "string"},
+                    "@module": {"enum": [cls.__module__], "type": "string"},
                     "@version": {"type": "string"},
                 },
                 "required": ["@class", "@module"],

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -365,8 +365,8 @@ class JsonTest(unittest.TestCase):
                     "title": "A",
                     "type": "object",
                     "properties": {
-                        "@class": {"const": "GoodMSONClass"},
-                        "@module": {"const": "tests.test_json"},
+                        "@class": {"enum": ["GoodMSONClass"], "type": "string"},
+                        "@module": {"enum": ["tests.test_json"], "type": "string"},
                         "@version": {"type": "string"},
                     },
                     "required": ["@class", "@module"],


### PR DESCRIPTION
## Summary

A small update to PR #191 since "const" is not yet supported by OpenAPI but "enum" is.

This update allows the new MP API which uses pydantic to self-document.

Tagging @shyamd to notify.