### PR TITLE
Allow serialisation of builtin functions

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -5,6 +5,7 @@ JSON serialization and deserialization utilities.
 
 import os
 import json
+import types
 import datetime
 
 from hashlib import sha1
@@ -471,8 +472,6 @@ def jsanitize(obj, strict=False, allow_bson=False):
 
 
 def _serialize_callable(o):
-    import types
-
     if isinstance(o, types.BuiltinFunctionType):
         # don't care about what builtin functions (sum, open, etc) are bound to
         bound = None

--- a/monty/json.py
+++ b/monty/json.py
@@ -471,15 +471,15 @@ def jsanitize(obj, strict=False, allow_bson=False):
 
 
 def _serialize_callable(o):
-    import builtins
+    import types
 
-    # bound methods (i.e., instance methods) have a __self__ attribute
-    # that points to the class/module/instance
-    bound = getattr(o, "__self__", None)
-
-    # don't care about what builtin functions (sum, open, etc) are bound to
-    if bound == builtins:
+    if isinstance(o, types.BuiltinFunctionType):
+        # don't care about what builtin functions (sum, open, etc) are bound to
         bound = None
+    else:
+        # bound methods (i.e., instance methods) have a __self__ attribute
+        # that points to the class/module/instance
+        bound = getattr(o, "__self__", None)
 
     # we are only able to serialize bound methods if the object the method is
     # bound to is itself serializable

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -319,6 +319,8 @@ class JsonTest(unittest.TestCase):
             # builtins
             str,
             list,
+            sum,
+            open,
             # functions
             os.path.join,
             my_callable,
@@ -357,7 +359,7 @@ class JsonTest(unittest.TestCase):
             self.assertEqual(x.__self__.as_dict(), function.__self__.as_dict())
 
         # test method bound to object that is not serializable
-        for function in [open, MethodNonSerializationClass(1).method]:
+        for function in [MethodNonSerializationClass(1).method]:
             self.assertRaises(TypeError, json.dumps, function, cls=MontyEncoder)
 
         # test that callable MSONable objects still get serialized as the objects
@@ -413,6 +415,8 @@ class JsonTest(unittest.TestCase):
             # builtins
             str,
             list,
+            sum,
+            open,
             # functions
             os.path.join,
             my_callable,
@@ -442,7 +446,7 @@ class JsonTest(unittest.TestCase):
             self.assertTrue("@class" in clean["f"]["@bound"])
 
         # test method bound to object that is not serializable
-        for function in [open, MethodNonSerializationClass(1).method]:
+        for function in [MethodNonSerializationClass(1).method]:
             d = {"f": function}
             clean = jsanitize(d)
             self.assertTrue(isinstance(clean["f"], str))


### PR DESCRIPTION
## Summary

My previous PR (#239) added support for serialising functions, methods, & classes. Builtin primitives (`str`, `int`, etc) and  classes (`list`, `set`, etc) also worked but builtin functions (`open`, `sum`, etc) did not.

This PR extends support for builtin functions.