### PR TITLE
Add support for serializing pydantic models

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -391,7 +391,7 @@ class MontyDecoder(json.JSONDecoder):
                     data = {k: v for k, v in d.items() if not k.startswith("@")}
                     if hasattr(cls_, "from_dict"):
                         return cls_.from_dict(data)
-                    elif pydantic is not None and issubclass(cls_, pydantic.BaseModel):
+                    if pydantic is not None and issubclass(cls_, pydantic.BaseModel):
                         return cls_(**data)
             elif np is not None and modname == "numpy" and classname == "array":
                 if d["dtype"].startswith("complex"):

--- a/monty/json.py
+++ b/monty/json.py
@@ -391,6 +391,8 @@ class MontyDecoder(json.JSONDecoder):
                     data = {k: v for k, v in d.items() if not k.startswith("@")}
                     if hasattr(cls_, "from_dict"):
                         return cls_.from_dict(data)
+                    elif pydantic is not None and issubclass(cls_, pydantic.BaseModel):
+                        return cls_(**data)
             elif np is not None and modname == "numpy" and classname == "array":
                 if d["dtype"].startswith("complex"):
                     return np.array(

--- a/monty/json.py
+++ b/monty/json.py
@@ -479,9 +479,7 @@ def jsanitize(obj, strict=False, allow_bson=False):
         return obj.__str__()
 
     if pydantic is not None and isinstance(obj, pydantic.BaseModel):
-        return jsanitize(
-            MontyEncoder().default(obj), strict=strict, allow_bson=allow_bson
-        )
+        return jsanitize(MontyEncoder().default(obj), strict=strict, allow_bson=allow_bson)
 
     return jsanitize(obj.as_dict(), strict=strict, allow_bson=allow_bson)
 

--- a/monty/json.py
+++ b/monty/json.py
@@ -22,6 +22,11 @@ except ImportError:
     np = None  # type: ignore
 
 try:
+    import pydantic
+except ImportError:
+    pydantic = None  # type: ignore
+
+try:
     import bson
 except ImportError:
     bson = None
@@ -268,6 +273,7 @@ class MontyEncoder(json.JSONEncoder):
             return {"@module": "datetime", "@class": "datetime", "string": o.__str__()}
         if isinstance(o, UUID):
             return {"@module": "uuid", "@class": "UUID", "string": o.__str__()}
+
         if np is not None:
             if isinstance(o, np.ndarray):
                 if str(o.dtype).startswith("complex"):
@@ -293,7 +299,11 @@ class MontyEncoder(json.JSONEncoder):
             return _serialize_callable(o)
 
         try:
-            d = o.as_dict()
+            if pydantic is not None and isinstance(o, pydantic.BaseModel):
+                d = o.dict()
+            else:
+                d = o.as_dict()
+
             if "@module" not in d:
                 d["@module"] = "{}".format(o.__class__.__module__)
             if "@class" not in d:
@@ -465,6 +475,11 @@ def jsanitize(obj, strict=False, allow_bson=False):
 
     if isinstance(obj, str):
         return obj.__str__()
+
+    if pydantic is not None and isinstance(obj, pydantic.BaseModel):
+        return jsanitize(
+            MontyEncoder().default(obj), strict=strict, allow_bson=allow_bson
+        )
 
     return jsanitize(obj.as_dict(), strict=strict, allow_bson=allow_bson)
 

--- a/pylintrc
+++ b/pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=
+extension-pkg-whitelist=pydantic
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -8,6 +8,7 @@ import datetime
 from bson.objectid import ObjectId
 from enum import Enum
 
+from pydantic import BaseModel
 from . import __version__ as tests_version
 from monty.json import MSONable, MontyEncoder, MontyDecoder, jsanitize
 from monty.json import _load_redirect
@@ -88,6 +89,10 @@ def my_callable(a, b):
 class EnumTest(MSONable, Enum):
     a = 1
     b = 2
+
+
+class ModelWithMSONable(BaseModel):
+    a: GoodMSONClass
 
 
 class MSONableTest(unittest.TestCase):
@@ -482,10 +487,6 @@ class JsonTest(unittest.TestCase):
         )
 
     def test_pydantic_integrations(self):
-        from pydantic import BaseModel
-
-        class ModelWithMSONable(BaseModel):
-            a: GoodMSONClass
 
         test_object = ModelWithMSONable(a=GoodMSONClass(1, 1, 1))
         test_dict_object = ModelWithMSONable(a=test_object.a.as_dict())
@@ -525,6 +526,10 @@ class JsonTest(unittest.TestCase):
             '@class': 'ModelWithMSONable',
             '@version': '0.1'
         }
+        obj = MontyDecoder().process_decoded(d)
+        assert isinstance(obj, BaseModel)
+        assert isinstance(obj.a, GoodMSONClass)
+        assert obj.a.b == 1
 
 
 if __name__ == "__main__":

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -509,6 +509,23 @@ class JsonTest(unittest.TestCase):
             "required": ["a"],
         }
 
+        d = jsanitize(test_object, strict=True)
+        assert d == {
+            'a': {
+                '@module': 'tests.test_json',
+                '@class': 'GoodMSONClass',
+                '@version': '0.1',
+                'a': 1,
+                'b': 1,
+                'c': 1,
+                'd': 1,
+                'values': []
+            },
+            '@module': 'tests.test_json',
+            '@class': 'ModelWithMSONable',
+            '@version': '0.1'
+        }
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -8,7 +8,6 @@ import datetime
 from bson.objectid import ObjectId
 from enum import Enum
 
-from pydantic import BaseModel
 from . import __version__ as tests_version
 from monty.json import MSONable, MontyEncoder, MontyDecoder, jsanitize
 from monty.json import _load_redirect
@@ -90,9 +89,6 @@ class EnumTest(MSONable, Enum):
     a = 1
     b = 2
 
-
-class ModelWithMSONable(BaseModel):
-    a: GoodMSONClass
 
 
 class MSONableTest(unittest.TestCase):
@@ -487,6 +483,12 @@ class JsonTest(unittest.TestCase):
         )
 
     def test_pydantic_integrations(self):
+        from pydantic import BaseModel
+
+        global ModelWithMSONable  # allow model to be deserialized in test
+
+        class ModelWithMSONable(BaseModel):
+            a: GoodMSONClass
 
         test_object = ModelWithMSONable(a=GoodMSONClass(1, 1, 1))
         test_dict_object = ModelWithMSONable(a=test_object.a.as_dict())


### PR DESCRIPTION
## Summary

Pydantic models are basically just fancy dictionaries. There is already partial support for pydantic models in monty, I just added support for serialising and deserialising them.

Note, I had to edit the pylintrc to work with pydantic. This is because pylint doesn't work well with c extensions as described here: https://github.com/samuelcolvin/pydantic/issues/1961