### PR TITLE
Add support for numpy generic types

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -459,7 +459,7 @@ def jsanitize(obj, strict=False, allow_bson=False):
         return [jsanitize(i, strict=strict, allow_bson=allow_bson) for i in obj]
     if np is not None and isinstance(obj, np.ndarray):
         return [jsanitize(i, strict=strict, allow_bson=allow_bson) for i in obj.tolist()]
-    if isinstance(obj, np.generic):
+    if np is not None and isinstance(obj, np.generic):
         return obj.item()
     if isinstance(obj, dict):
         return {k.__str__(): jsanitize(v, strict=strict, allow_bson=allow_bson) for k, v in obj.items()}

--- a/monty/json.py
+++ b/monty/json.py
@@ -459,6 +459,8 @@ def jsanitize(obj, strict=False, allow_bson=False):
         return [jsanitize(i, strict=strict, allow_bson=allow_bson) for i in obj]
     if np is not None and isinstance(obj, np.ndarray):
         return [jsanitize(i, strict=strict, allow_bson=allow_bson) for i in obj.tolist()]
+    if isinstance(obj, np.generic):
+        return obj.item()
     if isinstance(obj, dict):
         return {k.__str__(): jsanitize(v, strict=strict, allow_bson=allow_bson) for k, v in obj.items()}
     if isinstance(obj, (int, float)):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -314,6 +314,10 @@ class JsonTest(unittest.TestCase):
         self.assertEqual(type(x), np.ndarray)
         self.assertEqual(x.dtype, "complex64")
 
+        x = {"energies": [np.float64(1234.5)]}
+        d = jsanitize(x, strict=True)
+        assert type(d["energies"][0]) == float
+
     def test_callable(self):
         instance = MethodSerializationClass(a=1)
         for function in [


### PR DESCRIPTION
## Summary

Added support for numpy generic types (np.float32, np.int64, etc) in jsanitize. They were already supported in `MontyEncoder`.