### PR TITLE
Add support for pandas in jsanitize; add support for Series in MontyEncoder/MontyDecoder

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -426,7 +426,7 @@ class MontyDecoder(json.JSONDecoder):
                     if classname == "DataFrame":
                         decoded_data = MontyDecoder().decode(d["data"])
                         return pd.DataFrame(decoded_data)
-                    elif classname == "Series":
+                    if classname == "Series":
                         decoded_data = MontyDecoder().decode(d["data"])
                         return pd.Series(decoded_data)
                 elif (bson is not None) and modname == "bson.objectid" and classname == "ObjectId":


### PR DESCRIPTION
This PR implements two changes:
1. The `jsanitize` function now returns `DataFrame.to_dict()` and `Series.to_dict()` for pandas `DataFrame` and `Series` objects instead of returning them as `str`, which is the pre-existing (but not particularly ideal) approach. We are already dealing with pandas objects elsewhere in `monty.json`, so we might as well add it here too.
2. The `MontyEncoder`/`MontyDecoder` now supports pandas `Series` in addition to the pre-existing `DataFrame` support.

Tests have been added.