### PR TITLE
Add recursive_msonable kwarg to jsanitize

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -446,7 +446,7 @@ class MSONError(Exception):
     """
 
 
-def jsanitize(obj, strict=False, allow_bson=False, enum_values=False):
+def jsanitize(obj, strict=False, allow_bson=False, enum_values=False, recursive_msonable=False):
     """
     This method cleans an input json-like object, either a list or a dict or
     some sequence, nested or otherwise, by converting all non-string
@@ -462,10 +462,12 @@ def jsanitize(obj, strict=False, allow_bson=False, enum_values=False):
             strict is False, jsanitize will simply call str(object) to convert
             the object to a string representation.
         allow_bson (bool): This parameters sets the behavior when jsanitize
-            encounters an bson supported type such as objectid and datetime. If
+            encounters a bson supported type such as objectid and datetime. If
             True, such bson types will be ignored, allowing for proper
-            insertion into MongoDb databases.
+            insertion into MongoDB databases.
         enum_values (bool): Convert Enums to their values.
+        recursive_msonable (bool): If True, uses .as_dict() for MSONables regardless
+            of the value of strict.
 
     Returns:
         Sanitized dict that can be json serialized.
@@ -485,7 +487,9 @@ def jsanitize(obj, strict=False, allow_bson=False, enum_values=False):
         return obj.item()
     if isinstance(obj, dict):
         return {
-            k.__str__(): jsanitize(v, strict=strict, allow_bson=allow_bson, enum_values=enum_values)
+            k.__str__(): jsanitize(
+                v, strict=strict, allow_bson=allow_bson, enum_values=enum_values, recursive_msonable=recursive_msonable
+            )
             for k, v in obj.items()
         }
     if isinstance(obj, (int, float)):
@@ -499,6 +503,9 @@ def jsanitize(obj, strict=False, allow_bson=False, enum_values=False):
         except TypeError:
             pass
 
+    if recursive_msonable and isinstance(obj, MSONable):
+        return obj.as_dict()
+
     if not strict:
         return obj.__str__()
 
@@ -506,9 +513,21 @@ def jsanitize(obj, strict=False, allow_bson=False, enum_values=False):
         return obj.__str__()
 
     if pydantic is not None and isinstance(obj, pydantic.BaseModel):
-        return jsanitize(MontyEncoder().default(obj), strict=strict, allow_bson=allow_bson, enum_values=enum_values)
+        return jsanitize(
+            MontyEncoder().default(obj),
+            strict=strict,
+            allow_bson=allow_bson,
+            enum_values=enum_values,
+            recursive_msonable=recursive_msonable,
+        )
 
-    return jsanitize(obj.as_dict(), strict=strict, allow_bson=allow_bson, enum_values=enum_values)
+    return jsanitize(
+        obj.as_dict(),
+        strict=strict,
+        allow_bson=allow_bson,
+        enum_values=enum_values,
+        recursive_msonable=recursive_msonable,
+    )
 
 
 def _serialize_callable(o):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -427,6 +427,9 @@ class JsonTest(unittest.TestCase):
         clean_strict = jsanitize(d, strict=True)
         self.assertEqual(clean_strict["hello"]["a"], 1)
         self.assertEqual(clean_strict["hello"]["b"], 2)
+        clean_recursive_msonable = jsanitize(d, recursive_msonable=True)
+        self.assertEqual(clean_recursive_msonable["hello"]["a"], 1)
+        self.assertEqual(clean_recursive_msonable["hello"]["b"], 2)
 
         d = {"dt": datetime.datetime.now()}
         clean = jsanitize(d)


### PR DESCRIPTION
Addresses #343 by supporting conversion of `MSONable`s via `.as_dict()` in `jsanitize` with a new `recursive_msonable` kwarg.