### PR TITLE
Force `MontyDecoder` to fall back to python JSON decoder when `orjson` errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         args: ["--profile", "black"]
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/monty/json.py
+++ b/monty/json.py
@@ -477,7 +477,7 @@ class MontyDecoder(json.JSONDecoder):
         if orjson is not None:
             try:
                 d = orjson.loads(s)  # pylint: disable=E1101
-            except orjson.JSONDecodeError:
+            except orjson.JSONDecodeError:  # pylint: disable=E1101
                 d = json.loads(s)
         else:
             d = json.loads(s)

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -13,7 +13,7 @@ pydocstyle
 pydantic==1.9.0
 flake8
 pandas==1.4.1
-black
+black>=22.3.0
 pylint
 orjson==3.6.7
 types-orjson==3.6.2

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -178,13 +178,17 @@ class MSONableTest(unittest.TestCase):
                 "list5": [GMC(15, 15.0, "fifteen")],
             },
         ]
-        obj = GoodNestedMSONClass(a_list=a_list, b_dict=b_dict, c_list_dict_list=c_list_dict_list)
+        obj = GoodNestedMSONClass(
+            a_list=a_list, b_dict=b_dict, c_list_dict_list=c_list_dict_list
+        )
 
         self.assertEqual(
             a_list[0].unsafe_hash().hexdigest(),
             "ea44de0e2ef627be582282c02c48e94de0d58ec6",
         )
-        self.assertEqual(obj.unsafe_hash().hexdigest(), "44204c8da394e878f7562c9aa2e37c2177f28b81")
+        self.assertEqual(
+            obj.unsafe_hash().hexdigest(), "44204c8da394e878f7562c9aa2e37c2177f28b81"
+        )
 
     def test_version(self):
         obj = self.good_cls("Hello", "World", "Python")
@@ -215,7 +219,9 @@ class MSONableTest(unittest.TestCase):
                 "list5": [GMC(15, 15.0, "fifteen")],
             },
         ]
-        obj = GoodNestedMSONClass(a_list=a_list, b_dict=b_dict, c_list_dict_list=c_list_dict_list)
+        obj = GoodNestedMSONClass(
+            a_list=a_list, b_dict=b_dict, c_list_dict_list=c_list_dict_list
+        )
 
         obj_dict = obj.as_dict()
         obj2 = GoodNestedMSONClass.from_dict(obj_dict)
@@ -307,6 +313,12 @@ class JsonTest(unittest.TestCase):
         d = json.loads(jsonstr, cls=MontyDecoder)
         self.assertEqual(type(d["uuid"]), UUID)
 
+    def test_nan(self):
+        x = [float("NaN")]
+        djson = json.dumps(x, cls=MontyEncoder)
+        d = json.loads(djson)
+        self.assertEqual(type(d[0]), float)
+
     def test_numpy(self):
         x = np.array([1, 2, 3], dtype="int64")
         self.assertRaises(TypeError, json.dumps, x)
@@ -339,7 +351,9 @@ class JsonTest(unittest.TestCase):
         d = json.loads(djson)
         self.assertEqual(d["@class"], "array")
         self.assertEqual(d["@module"], "numpy")
-        self.assertEqual(d["data"], [[[1.0, 2.0], [3.0, 4.0]], [[1.0, 1.0], [1.0, 1.0]]])
+        self.assertEqual(
+            d["data"], [[[1.0, 2.0], [3.0, 4.0]], [[1.0, 1.0], [1.0, 1.0]]]
+        )
         self.assertEqual(d["dtype"], "complex64")
         x = json.loads(djson, cls=MontyDecoder)
         self.assertEqual(type(x), np.ndarray)
@@ -357,7 +371,10 @@ class JsonTest(unittest.TestCase):
 
         self.assertEqual(d["np_a"]["a"][0]["b"]["@module"], "numpy")
         self.assertEqual(d["np_a"]["a"][0]["b"]["@class"], "array")
-        self.assertEqual(d["np_a"]["a"][0]["b"]["data"], [[[1.0, 2.0], [3.0, 4.0]], [[1.0, 1.0], [1.0, 1.0]]])
+        self.assertEqual(
+            d["np_a"]["a"][0]["b"]["data"],
+            [[[1.0, 2.0], [3.0, 4.0]], [[1.0, 1.0], [1.0, 1.0]]],
+        )
         self.assertEqual(d["np_a"]["a"][0]["b"]["dtype"], "complex64")
 
         obj = ClassContainingNumpyArray.from_dict(d)
@@ -367,7 +384,9 @@ class JsonTest(unittest.TestCase):
 
     def test_pandas(self):
 
-        cls = ClassContainingDataFrame(df=pd.DataFrame([{"a": 1, "b": 1}, {"a": 1, "b": 2}]))
+        cls = ClassContainingDataFrame(
+            df=pd.DataFrame([{"a": 1, "b": 1}, {"a": 1, "b": 2}])
+        )
 
         d = json.loads(MontyEncoder().encode(cls))
 
@@ -391,7 +410,9 @@ class JsonTest(unittest.TestCase):
         self.assertIsInstance(obj.s, pd.Series)
         self.assertEqual(list(obj.s.a), [1, 2, 3])
 
-        cls = ClassContainingSeries(s={"df": [pd.Series({"a": [1, 2, 3], "b": [4, 5, 6]})]})
+        cls = ClassContainingSeries(
+            s={"df": [pd.Series({"a": [1, 2, 3], "b": [4, 5, 6]})]}
+        )
 
         d = json.loads(MontyEncoder().encode(cls))
 
@@ -563,7 +584,9 @@ class JsonTest(unittest.TestCase):
         self.assertEqual(clean, s.to_dict())
 
     def test_redirect(self):
-        MSONable.REDIRECT["tests.test_json"] = {"test_class": {"@class": "GoodMSONClass", "@module": "tests.test_json"}}
+        MSONable.REDIRECT["tests.test_json"] = {
+            "test_class": {"@class": "GoodMSONClass", "@module": "tests.test_json"}
+        }
 
         d = {
             "@class": "test_class",
@@ -584,7 +607,11 @@ class JsonTest(unittest.TestCase):
         data = _load_redirect(os.path.join(test_dir, "test_settings.yaml"))
         self.assertEqual(
             data,
-            {"old_module": {"old_class": {"@class": "new_class", "@module": "new_module"}}},
+            {
+                "old_module": {
+                    "old_class": {"@class": "new_class", "@module": "new_module"}
+                }
+            },
         )
 
     def test_pydantic_integrations(self):


### PR DESCRIPTION
## Summary

This PR forces `MontyDecoder` to try and fall back to the native python JSON decoder when an `orjson.JSONDecodeError` is thrown. This addresses instances where special float types like `float.NaN` exist in the target data. These are handled fine by the native python library, but not `orjson` as it takes a stricter approach to conforming to JSON schema standards.  
