### PR TITLE
Support pathlib.Path in jsanitize

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -5,6 +5,7 @@ JSON serialization and deserialization utilities.
 import datetime
 import json
 import os
+import pathlib
 import types
 from collections import OrderedDict, defaultdict
 from enum import Enum
@@ -516,6 +517,8 @@ def jsanitize(obj, strict=False, allow_bson=False, enum_values=False, recursive_
         return obj
     if obj is None:
         return None
+    if isinstance(obj, pathlib.Path):
+        return str(obj)
 
     if callable(obj) and not isinstance(obj, MSONable):
         try:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -3,6 +3,7 @@ __version__ = "0.1"
 import datetime
 import json
 import os
+import pathlib
 import unittest
 from enum import Enum
 
@@ -510,6 +511,10 @@ class JsonTest(unittest.TestCase):
         clean = jsanitize(d, allow_bson=True)
         self.assertEqual(clean["a"], bytes(rnd_bin))
         self.assertIsInstance(clean["a"], bytes)
+
+        p = pathlib.Path("/home/user/")
+        clean = jsanitize(p, strict=True)
+        self.assertEqual(clean, "/home/user")
 
         # test jsanitizing callables (including classes)
         instance = MethodSerializationClass(a=1)


### PR DESCRIPTION
## Summary

- This PR adds support of `pathlib.Path` in `jsanitize` such that it works when `strict=True`.  
