### PR TITLE
Add generic types to @cached_class

### DIFF
--- a/monty/design_patterns.py
+++ b/monty/design_patterns.py
@@ -4,6 +4,7 @@ Some common design patterns such as singleton and cached classes.
 
 import os
 from functools import wraps
+from typing import TypeVar
 
 
 def singleton(cls):
@@ -29,7 +30,10 @@ def singleton(cls):
     return getinstance
 
 
-def cached_class(klass):
+Klass = TypeVar("Klass")
+
+
+def cached_class(klass: type[Klass]) -> type[Klass]:
     """
     Decorator to cache class instances by constructor arguments.
     This results in a class that behaves like a singleton for each


### PR DESCRIPTION
Solves the issue reported in https://github.com/microsoft/pylance-release/issues/3478 that `@cached_class` obscures the methods on a decorated class from auto-completion and doc string lookup (at least in VS Code and presumably most other IDEs).