### PR TITLE
Explicitely use safe yaml

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -57,7 +57,7 @@ def _load_redirect(redirect_file):
     try:
         with open(redirect_file) as f:
             yaml = YAML()
-            d = yaml.load(f)
+            d = yaml.load(f, typ="safe")
     except OSError:
         # If we can't find the file
         # Just use an empty redirect dict

--- a/monty/json.py
+++ b/monty/json.py
@@ -57,7 +57,7 @@ def _load_redirect(redirect_file):
     try:
         with open(redirect_file) as f:
             yaml = YAML()
-            d = yaml.load(f, typ="safe")
+            d = yaml.load(f, typ="safe", pure=True)
     except OSError:
         # If we can't find the file
         # Just use an empty redirect dict


### PR DESCRIPTION
Ruamel's [documentation]( https://yaml.readthedocs.io/en/latest/dumpcls.html ) is scary and confusing, having the following on the **same page**:

> Only yaml = YAML(typ='unsafe') loads and dumps Python objects out-of-the-box. And since it loads any Python object, this can be unsafe.

```
import sys
import ruamel.yaml


class User(object):
    def __init__(self, name, age):
        self.name = name
        self.age = age


yaml = ruamel.yaml.YAML()
yaml.register_class(User)
yaml.dump([User('Anthon', 18)], sys.stdout)
```

So let's explicitly use the safe variant of yaml parser, and hope for the best.
