### PR TITLE
Fix handling of `datetime` in `jsanitize`

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -536,7 +536,7 @@ def jsanitize(obj, strict=False, allow_bson=False, enum_values=False, recursive_
         return obj
     if obj is None:
         return None
-    if isinstance(obj, pathlib.Path):
+    if isinstance(obj, pathlib.Path) or isinstance(obj, datetime.datetime):
         return str(obj)
 
     if callable(obj) and not isinstance(obj, MSONable):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 from bson.objectid import ObjectId
 
-from monty.json import jsanitize, MontyDecoder, MontyEncoder, MSONable, _load_redirect, jsanitize
+from monty.json import MontyDecoder, MontyEncoder, MSONable, _load_redirect, jsanitize
 
 from . import __version__ as tests_version
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 from bson.objectid import ObjectId
 
-from monty.json import MontyDecoder, MontyEncoder, MSONable, _load_redirect, jsanitize
+from monty.json import jsanitize, MontyDecoder, MontyEncoder, MSONable, _load_redirect, jsanitize
 
 from . import __version__ as tests_version
 
@@ -313,6 +313,8 @@ class JsonTest(unittest.TestCase):
         jsonstr = json.dumps(a, cls=MontyEncoder)
         d = json.loads(jsonstr, cls=MontyDecoder)
         self.assertEqual(type(d["dt"]), datetime.datetime)
+
+        jsanitize(dt, strict=True)
 
     def test_uuid(self):
         from uuid import UUID, uuid4


### PR DESCRIPTION
Currently, the `jsanitize()` command in `monty` throws an error if `strict=True` and a `datetime` object is supplied. It's better if we just handle `datetime` objects directly in `jsanitize` given how often they crop up anyway.