### PR TITLE
Pydantic v2 support for MSONable types

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -227,7 +227,7 @@ class MSONable:
             )
 
     @classmethod
-    def validate_monty(cls, __input_value, _):
+    def validate_monty(cls, __input_value, *agrs, **kwargs):
         """
         pydantic Validator for MSONable pattern
         """
@@ -257,6 +257,26 @@ class MSONable:
                 },
                 "required": ["@class", "@module"],
             }
+    
+    @classmethod
+    def __get_validators__(cls):
+        """Return validators for use in pydantic"""
+        yield cls.validate_monty
+
+    @classmethod
+    def __modify_schema__(cls, field_schema):
+        """JSON schema for MSONable pattern"""
+        field_schema.update(
+            {
+                "type": "object",
+                "properties": {
+                    "@class": {"enum": [cls.__name__], "type": "string"},
+                    "@module": {"enum": [cls.__module__], "type": "string"},
+                    "@version": {"type": "string"},
+                },
+                "required": ["@class", "@module"],
+            }
+        )
 
 
 

--- a/monty/json.py
+++ b/monty/json.py
@@ -25,9 +25,13 @@ except ImportError:
 
 try:
     import pydantic
-    from pydantic_core import core_schema
 except ImportError:
     pydantic = None  # type: ignore
+
+try:
+    from pydantic_core import core_schema
+except ImportError:
+    core_schema = None  # type: ignore
 
 try:
     import bson
@@ -216,6 +220,12 @@ class MSONable:
     def __get_pydantic_core_schema__(
         cls, source_type, handler
     ):
+        """
+        pydantic v2 core schema definition
+        """
+        if core_schema is None:
+            raise RuntimeError("Pydantic >= 2.0 is required for validation")
+
         s = core_schema.general_plain_validator_function(cls.validate_monty)
 
         return core_schema.json_or_python_schema(
@@ -227,7 +237,7 @@ class MSONable:
             )
 
     @classmethod
-    def validate_monty(cls, __input_value, *agrs, **kwargs):
+    def validate_monty(cls, __input_value, *args, **kwargs):
         """
         pydantic Validator for MSONable pattern
         """

--- a/monty/json.py
+++ b/monty/json.py
@@ -217,9 +217,7 @@ class MSONable:
         return sha1(json.dumps(OrderedDict(ordered_keys)).encode("utf-8"))
 
     @classmethod
-    def __get_pydantic_core_schema__(
-        cls, source_type, handler
-    ):
+    def __get_pydantic_core_schema__(cls, source_type, handler):
         """
         pydantic v2 core schema definition
         """
@@ -229,12 +227,10 @@ class MSONable:
         s = core_schema.general_plain_validator_function(cls.validate_monty)
 
         return core_schema.json_or_python_schema(
-                json_schema=s,
-                python_schema=s,
-                serialization=core_schema.plain_serializer_function_ser_schema(
-                    lambda instance: instance.as_dict()
-                ),
-            )
+            json_schema=s,
+            python_schema=s,
+            serialization=core_schema.plain_serializer_function_ser_schema(lambda instance: instance.as_dict()),
+        )
 
     @classmethod
     def validate_monty(cls, __input_value, *args, **kwargs):
@@ -259,15 +255,15 @@ class MSONable:
         """JSON schema for MSONable pattern"""
 
         return {
-                "type": "object",
-                "properties": {
-                    "@class": {"enum": [cls.__name__], "type": "string"},
-                    "@module": {"enum": [cls.__module__], "type": "string"},
-                    "@version": {"type": "string"},
-                },
-                "required": ["@class", "@module"],
-            }
-    
+            "type": "object",
+            "properties": {
+                "@class": {"enum": [cls.__name__], "type": "string"},
+                "@module": {"enum": [cls.__module__], "type": "string"},
+                "@version": {"type": "string"},
+            },
+            "required": ["@class", "@module"],
+        }
+
     @classmethod
     def __get_validators__(cls):
         """Return validators for use in pydantic"""
@@ -287,7 +283,6 @@ class MSONable:
                 "required": ["@class", "@module"],
             }
         )
-
 
 
 class MontyEncoder(json.JSONEncoder):


### PR DESCRIPTION
## Summary

This PR adds support for pydantic >= 2.0 with the addition of custom class validation methods to `MSONable`:
- `__get_pydantic_json_schema__` to define pydantic field JSON schema
- `__get_pydantic_core_schema__` to define pydantic field core schema

The same validation function is used for both versions.

