### PR TITLE
Update pydantic deserialization

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -481,7 +481,8 @@ class MontyDecoder(json.JSONDecoder):
                         if hasattr(cls_, "from_dict"):
                             return cls_.from_dict(data)
                         if pydantic is not None and issubclass(cls_, pydantic.BaseModel):  # pylint: disable=E1101
-                            return cls_(**data)
+                            d = {k: self.process_decoded(v) for k, v in data.items()}
+                            return cls_(**d)
                         if (
                             dataclasses is not None
                             and (not issubclass(cls_, MSONable))


### PR DESCRIPTION
Currently a pydantic `BaseModel` will deserialize an MSONable oject inside it only if it explicitly declared.
For example the code below
```python
from pydantic import BaseModel
from monty.json import MSONable, MontyDecoder
from monty.json import jsanitize


class MSONObject(MSONable):
    def __init__(self, a):
        self.a = a


class ModelWithMSONable(BaseModel):
    a: MSONObject

class ModelWithDict(BaseModel):
    a: dict

test_object = ModelWithMSONable(a=MSONObject(1))
d = jsanitize(test_object, strict=True, enum_values=True, allow_bson=True)
obj = MontyDecoder().process_decoded(d)

print(obj)

test_object = ModelWithDict(a={"x": MSONObject(1)})
d = jsanitize(test_object, strict=True, enum_values=True, allow_bson=True)
obj = MontyDecoder().process_decoded(d)

print(obj)
```
prints

```
a=<__main__.MSONObject object at 0x1307e3c10>
a={'x': {'@module': '__main__', '@class': 'MSONObject', '@version': None, 'a': 1}}
```

Similar cases can be found in emmet, where the contained object are not always explicitly declared (e.g. https://github.com/materialsproject/emmet/blob/b2cedcf1d83e41eeac4dd9a28048f8786452516d/emmet-core/emmet/core/tasks.py#L364). 

I expected the MontyDecoder to handle these kind of cases, so I am proposing to add an explicit deserialization for the content of pydantic BaseModels, similarly to what is done for dataclasses.