### PR TITLE
Add support for serializing ase Atoms objects

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -8,3 +8,4 @@ pandas==2.1.1
 orjson==3.9.9
 types-orjson==3.6.2
 types-requests==2.31.0.10
+ase==3.22.1

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -7,9 +7,9 @@ import os
 import pathlib
 from enum import Enum
 
+import ase
 import numpy as np
 import pandas as pd
-import ase
 import pytest
 import torch
 from bson.objectid import ObjectId
@@ -322,7 +322,7 @@ class TestJson:
             cell=[[3, 0, 0], [0, 3, 0], [0, 0, 3]],
             numbers=[1, 1, 1],
             positions=[[0, 0, 0], [1, 1, 1], [2, 2, 2]],
-            pbc=[True, True, True]
+            pbc=[True, True, True],
         )
         jsonstr = json.dumps(atoms, cls=MontyEncoder)
         atoms2 = json.loads(jsonstr, cls=MontyDecoder)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -327,7 +327,7 @@ class TestJson:
         jsonstr = json.dumps(atoms, cls=MontyEncoder)
         atoms2 = json.loads(jsonstr, cls=MontyDecoder)
         assert isinstance(atoms2, ase.Atoms)
-        assert atoms2.numbers == atoms.numbers
+        assert tuple(atoms2.numbers) == tuple(atoms.numbers)
         assert all(atoms2.pbc)
 
         sanitized = jsanitize({"a": atoms}, strict=True)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -9,6 +9,7 @@ from enum import Enum
 
 import numpy as np
 import pandas as pd
+import ase
 import pytest
 import torch
 from bson.objectid import ObjectId
@@ -315,6 +316,23 @@ class TestJson:
         assert isinstance(t2, torch.Tensor)
         assert t2.type() == t.type()
         assert np.array_equal(t2, t)
+
+    def test_ase(self):
+        atoms = ase.Atoms(
+            cell=[[3, 0, 0], [0, 3, 0], [0, 0, 3]],
+            numbers=[1, 1, 1],
+            positions=[[0, 0, 0], [1, 1, 1], [2, 2, 2]],
+            pbc=[True, False, True]
+        )
+        jsonstr = json.dumps(atoms, cls=MontyEncoder)
+        atoms2 = json.loads(jsonstr, cls=MontyDecoder)
+        assert isinstance(atoms2, ase.Atoms)
+        assert atoms2.numbers == atoms.numbers
+        assert atoms2.pbc == [True, False, True]
+
+        sanitized = jsanitize({"a": atoms}, strict=True)
+        assert sanitized["a"]["@class"] == "Atoms"
+        assert sanitized["a"]["@module"] == "ase"
 
     def test_datetime(self):
         dt = datetime.datetime.now()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -322,13 +322,13 @@ class TestJson:
             cell=[[3, 0, 0], [0, 3, 0], [0, 0, 3]],
             numbers=[1, 1, 1],
             positions=[[0, 0, 0], [1, 1, 1], [2, 2, 2]],
-            pbc=[True, False, True]
+            pbc=[True, True, True]
         )
         jsonstr = json.dumps(atoms, cls=MontyEncoder)
         atoms2 = json.loads(jsonstr, cls=MontyDecoder)
         assert isinstance(atoms2, ase.Atoms)
         assert atoms2.numbers == atoms.numbers
-        assert atoms2.pbc == [True, False, True]
+        assert all(atoms2.pbc)
 
         sanitized = jsanitize({"a": atoms}, strict=True)
         assert sanitized["a"]["@class"] == "Atoms"


### PR DESCRIPTION
This PR adds support for serializing ase `Atoms` objects.

We've found this might be a useful feature to have in atomate2. But I think it could be useful more broadly. E.g., `Atoms` objects are used in the MD interface in `matgl`, in `chgnet`, and `quacc` (developed by @Andrew-S-Rosen). Although I understand if this sort of feature is outside the scope of monty.