### PR TITLE
Handle Enums in serialization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,9 @@ repos:
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
+        exclude: ^tests
       - id: trailing-whitespace
+        exclude: ^tests
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.6.1

--- a/monty/json.py
+++ b/monty/json.py
@@ -404,6 +404,8 @@ class MontyEncoder(json.JSONEncoder):
         try:
             if pydantic is not None and isinstance(o, pydantic.BaseModel):
                 d = o.dict()
+            elif isinstance(o, Enum):
+                d = {"value": o.value}
             elif (
                 dataclasses is not None
                 and (not issubclass(o.__class__, MSONable))
@@ -513,6 +515,8 @@ class MontyDecoder(json.JSONDecoder):
                         data = {k: v for k, v in d.items() if not k.startswith("@")}
                         if hasattr(cls_, "from_dict"):
                             return cls_.from_dict(data)
+                        if issubclass(cls_, Enum):
+                            return cls_(d["value"])
                         if pydantic is not None and issubclass(
                             cls_, pydantic.BaseModel
                         ):  # pylint: disable=E1101

--- a/monty/pprint.py
+++ b/monty/pprint.py
@@ -90,7 +90,7 @@ class DisplayEcoder(JSONEncoder):
 
     def default(self, o):
         """
-        Try diffent ways of converting the present object for displaying
+        Try different ways of converting the present object for displaying
         """
         try:
             return o.as_dict()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -20,6 +20,11 @@ from . import __version__ as tests_version
 test_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_files")
 
 
+class A(Enum):
+    name_a = "value_a"
+    name_b = "value_b"
+
+
 class GoodMSONClass(MSONable):
     def __init__(self, a, b, c, d=1, *values, **kwargs):
         self.a = a
@@ -766,10 +771,6 @@ class TestJson:
         assert isinstance(ndc2, NestedDataClass)
 
     def test_enum(self):
-        class A(Enum):
-            name_a = "value_a"
-            name_b = "value_b"
-
         s = MontyEncoder().encode(A.name_a)
         p = MontyDecoder().decode(s)
         assert p.name == "name_a"

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -764,3 +764,13 @@ class TestJson:
         str_ = json.dumps(ndc, cls=MontyEncoder)
         ndc2 = json.loads(str_, cls=MontyDecoder)
         assert isinstance(ndc2, NestedDataClass)
+
+    def test_enum(self):
+        class A(Enum):
+            name_a = "value_a"
+            name_b = "value_b"
+
+        s = MontyEncoder().encode(A.a)
+        p = MontyDecoder().decode(s)
+        assert p.name == "name_a"
+        assert p.value == "value_a"

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -770,7 +770,7 @@ class TestJson:
             name_a = "value_a"
             name_b = "value_b"
 
-        s = MontyEncoder().encode(A.a)
+        s = MontyEncoder().encode(A.name_a)
         p = MontyDecoder().decode(s)
         assert p.name == "name_a"
         assert p.value == "value_a"


### PR DESCRIPTION
## Handle Enums in serialization

Allow encoding and decoding of `Enum` subclasses.

Addresses 
https://github.com/materialsproject/emmet/issues/919

## Minor fixes to linting

CI was making changes to the white spaces in test files which led to some of the tests breaking.
Now avoids basic formatting change in the test files.=