### PR TITLE
[BUG] Enum subclasses with custom `as_dict`, `from_dict` breaks

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -412,8 +412,6 @@ class MontyEncoder(json.JSONEncoder):
         try:
             if pydantic is not None and isinstance(o, pydantic.BaseModel):
                 d = o.dict()
-            elif isinstance(o, Enum):
-                d = {"value": o.value}
             elif (
                 dataclasses is not None
                 and (not issubclass(o.__class__, MSONable))
@@ -421,8 +419,14 @@ class MontyEncoder(json.JSONEncoder):
             ):
                 # This handles dataclasses that are not subclasses of MSONAble.
                 d = dataclasses.asdict(o)
-            else:
+            elif hasattr(o, "as_dict"):
                 d = o.as_dict()
+            elif isinstance(o, Enum):
+                d = {"value": o.value}
+            else:
+                raise TypeError(
+                    f"Object of type {o.__class__.__name__} is not JSON serializable"
+                )
 
             if "@module" not in d:
                 d["@module"] = str(o.__class__.__module__)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -20,11 +20,6 @@ from . import __version__ as tests_version
 test_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_files")
 
 
-class A(Enum):
-    name_a = "value_a"
-    name_b = "value_b"
-
-
 class GoodMSONClass(MSONable):
     def __init__(self, a, b, c, d=1, *values, **kwargs):
         self.a = a
@@ -103,6 +98,23 @@ class MethodNonSerializationClass:
 
 def my_callable(a, b):
     return a + b
+
+
+class EnumNoAsDict(Enum):
+    name_a = "value_a"
+    name_b = "value_b"
+
+
+class EnumAsDict(Enum):
+    name_a = "value_a"
+    name_b = "value_b"
+
+    def as_dict(self):
+        return {"v": self.value}
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(d["v"])
 
 
 class EnumTest(MSONable, Enum):
@@ -815,7 +827,13 @@ class TestJson:
         assert isinstance(ndc2, NestedDataClass)
 
     def test_enum(self):
-        s = MontyEncoder().encode(A.name_a)
+        s = MontyEncoder().encode(EnumNoAsDict.name_a)
         p = MontyDecoder().decode(s)
         assert p.name == "name_a"
         assert p.value == "value_a"
+
+        na1 = EnumAsDict.name_a
+        d_ = na1.as_dict()
+        assert d_ == {"v": "value_a"}
+        na2 = EnumAsDict.from_dict(d_)
+        assert na2 == na1


### PR DESCRIPTION
## Small bug in Enum Serialization
Addresses: https://github.com/materialsvirtuallab/monty/issues/610

If an Enum subclass like `Element` has a custom `as_dict`/`from_dict`, then it should be the preferred method for serialization.

The original order of the if statements check for `Enum` before it checked if custom constructors which breaks some tests in pymatgen.
