### PR TITLE
Add support for keyword-only args

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -173,7 +173,6 @@ class MSONable:
             d["@version"] = None  # type: ignore
 
         spec = getfullargspec(self.__class__.__init__)
-        args = spec.args
 
         def recursive_as_dict(obj):
             if isinstance(obj, (list, tuple)):
@@ -193,7 +192,7 @@ class MSONable:
                 return d
             return obj
 
-        for c in args:
+        for c in spec.args + spec.kwonlyargs:
             if c != "self":
                 try:
                     a = getattr(self, c)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -185,6 +185,12 @@ class TestMSONable:
 
         self.auto_mson = AutoMSON
 
+        class ClassContainingKWOnlyArgs(MSONable):
+            def __init__(self, *, a):
+                self.a = a
+
+        self.kw_only_args_cls = ClassContainingKWOnlyArgs
+
     def test_to_from_dict(self):
         obj = self.good_cls("Hello", "World", "Python")
         d = obj.as_dict()
@@ -204,6 +210,16 @@ class TestMSONable:
         obj = self.auto_mson(2, 3)
         d = obj.as_dict()
         self.auto_mson.from_dict(d)
+
+    def test_kw_only_args(self):
+        obj = self.kw_only_args_cls(a=1)
+        d = obj.as_dict()
+        assert d is not None
+        assert d["a"] == 1
+        self.kw_only_args_cls.from_dict(d)
+        jsonstr = obj.to_json()
+        d = json.loads(jsonstr)
+        assert d["@class"], "ClassContainingKWOnlyArgs"
 
     def test_unsafe_hash(self):
         GMC = GoodMSONClass


### PR DESCRIPTION
## Summary

Add support for keyword-only arguments. Consider the following example class:

```
class KwOnlyTest(MSONable):
    def __init__(self, a, *, b):
        self.a = a
        self.b = b

obj = KwOnlyTest(2, b=3)
```

Looking at the args: `getfullargspec(obj.__class__.__init__)` one gets `FullArgSpec(args=['self', 'a'], varargs=None, varkw=None, defaults=None, kwonlyargs=['b'], kwonlydefaults=None, annotations={})`. Here you can see the difference between `args` and `kwonlyargs`. The old implementation uses only the `args`, resulting in missing `b` in the `as_dict()` representation.

I changed it to use `args` and `kwonlyargs`. This fixes the issue and `b` is now included in the dict representation.

## Checklist

- [ x ] Google format doc strings added. Check with `ruff`.
- [ x ] Type annotations included. Check with `mypy`.
- [ x ] Tests added for new features/fixes.
