### PR TITLE
Run macOS CI on faster M1 runners + reuse test workflow as job in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,56 +7,55 @@ on:
 
 jobs:
   build:
-
     strategy:
       max-parallel: 3
       matrix:
         os: [macos-latest]
-        python-version: ['3.9']
+        python-version: ["3.9"]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        # Note that this is a must because pylint is done based on a previous tag.
-        fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-optional.txt -r requirements-ci.txt
-        pip install -e .
-    - name: mypy
-      run: |
-        mypy monty
-    - name: flake8
-      run: |
-        flake8 --count --show-source --statistics monty
-        # exit-zero treats all errors as warnings.
-        flake8 --count --exit-zero --max-complexity=20 --statistics monty
-    - name: pydocstyle
-      run: |
-        pydocstyle --count monty
-    - name: Lint with pylint
-      run: |
-        pylint monty
-    - name: black
-      run: |
-        black --version
-        black --check --diff --color monty
-    - name: pytest
-      run: |
-        pytest tests --color=yes
-    - name: release
-      env:
-        TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-      run: |
-        pip install setuptools wheel twine
-        python setup.py sdist bdist_wheel
-        twine upload --skip-existing dist/*.whl
-        twine upload --skip-existing dist/*.tar.gz
+      - uses: actions/checkout@v2
+        with:
+          # Note that this is a must because pylint is done based on a previous tag.
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-optional.txt -r requirements-ci.txt
+          pip install -e .
+      - name: mypy
+        run: |
+          mypy monty
+      - name: flake8
+        run: |
+          flake8 --count --show-source --statistics monty
+          # exit-zero treats all errors as warnings.
+          flake8 --count --exit-zero --max-complexity=20 --statistics monty
+      - name: pydocstyle
+        run: |
+          pydocstyle --count monty
+      - name: Lint with pylint
+        run: |
+          pylint monty
+      - name: black
+        run: |
+          black --version
+          black --check --diff --color monty
+      - name: pytest
+        run: |
+          pytest tests --color=yes
+      - name: release
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        run: |
+          pip install setuptools wheel twine
+          python setup.py sdist bdist_wheel
+          twine upload --skip-existing dist/*.whl
+          twine upload --skip-existing dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,36 +20,22 @@ jobs:
         with:
           # Note that this is a must because pylint is done based on a previous tag.
           fetch-depth: 0
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-optional.txt -r requirements-ci.txt
           pip install -e .
-      - name: mypy
-        run: |
-          mypy monty
-      - name: flake8
-        run: |
-          flake8 --count --show-source --statistics monty
-          # exit-zero treats all errors as warnings.
-          flake8 --count --exit-zero --max-complexity=20 --statistics monty
-      - name: pydocstyle
-        run: |
-          pydocstyle --count monty
-      - name: Lint with pylint
-        run: |
-          pylint monty
-      - name: black
-        run: |
-          black --version
-          black --check --diff --color monty
+
       - name: pytest
         run: |
           pytest tests --color=yes
+
       - name: release
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  test:
+    # run test.yml first to ensure that the test suite is passing
+    uses: ./.github/workflows/test.yml
+
   build:
+    needs: test
     strategy:
       max-parallel: 3
       matrix:
         os: [macos-14]
         python-version: ["3.9"]
-
     runs-on: ${{ matrix.os }}
-
     steps:
       - uses: actions/checkout@v4
 
@@ -23,22 +26,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-optional.txt -r requirements-ci.txt
-          pip install -e .
-
-      - name: pytest
-        run: |
-          pytest tests --color=yes
-
       - name: release
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
-          pip install setuptools wheel twine
-          python setup.py sdist bdist_wheel
-          twine upload --skip-existing dist/*.whl
-          twine upload --skip-existing dist/*.tar.gz
+          pip install build twine
+          python -m build
+          twine upload --skip-existing dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          # Note that this is a must because pylint is done based on a previous tag.
-          fetch-depth: 0
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [macos-latest]
+        os: [macos-14]
         python-version: ["3.9"]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,30 +4,29 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     strategy:
       max-parallel: 20
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10']
+        python-version: ["3.10"]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-optional.txt -r requirements-ci.txt
-        pip install -e .
-    - name: pytest
-      run: |
-        pytest --cov=monty --cov-report html:coverage_reports monty tests
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-optional.txt -r requirements-ci.txt
+          pip install -e .
+      - name: pytest
+        run: |
+          pytest --cov=monty --cov-report html:coverage_reports monty tests
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       max-parallel: 20
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
         python-version: ["3.10"]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,19 +13,22 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-optional.txt -r requirements-ci.txt
           pip install -e .
+
       - name: pytest
-        run: |
-          pytest --cov=monty --cov-report html:coverage_reports monty tests
+        run: pytest --cov=monty --cov-report html:coverage_reports monty tests
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Testing
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_call]
 
 jobs:
   build:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.2.1
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
b5390f8 auto fix whitespace
563ca8c remove linting steps from release CI
f3820d9 macos-latest -> macos-14 to run on newer+faster M1 runners
b9d622e bump GitHub Actions checkout + setup-python versions
e3120ae reuse test workflow as job in release workflow