### PR TITLE
Make `requires` decorator accept custom error class

### DIFF
--- a/monty/dev.py
+++ b/monty/dev.py
@@ -76,13 +76,16 @@ class requires:
         message: A message to be displayed if the condition is not True.
     """
 
-    def __init__(self, condition, message):
+    def __init__(
+        self, condition: bool, message: str, err_cls: Exception = RuntimeError
+    ) -> None:
         """
         :param condition: A expression returning a bool.
         :param message: Message to display if condition is False.
         """
         self.condition = condition
         self.message = message
+        self.err_cls = err_cls
 
     def __call__(self, _callable):
         """
@@ -92,7 +95,7 @@ class requires:
         @functools.wraps(_callable)
         def decorated(*args, **kwargs):
             if not self.condition:
-                raise RuntimeError(self.message)
+                raise self.err_cls(self.message)
             return _callable(*args, **kwargs)
 
         return decorated

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -113,18 +113,28 @@ class TestDecorator:
         except ImportError:
             fictitious_mod = None  # type: ignore
 
-        @requires(fictitious_mod is not None, "fictitious_mod is not present.")
+        err_msg = "fictitious_mod is not present."
+
+        @requires(fictitious_mod is not None, err_msg)
         def use_fictitious_mod():
             print("success")
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match=err_msg):
             use_fictitious_mod()
 
-        @requires(unittest is not None, "scipy is not present.")
+        @requires(unittest is not None, "unittest is not present.")
         def use_unittest():
             return "success"
 
         assert use_unittest() == "success"
+
+        # test with custom error class
+        @requires(False, "expect ImportError", err_cls=ImportError)
+        def use_import_error():
+            return "success"
+
+        with pytest.raises(ImportError, match="expect ImportError"):
+            use_import_error()
 
     def test_install_except_hook(self):
         install_excepthook()


### PR DESCRIPTION
75e31f1 make `requires` decorator accept custom error class as `err_cls`
4d67461 `test_requires` with `err_cls=ImportError`