### PR TITLE
Check for symlinks when using `copy_r` and/or `compress_file`

### DIFF
--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -79,7 +79,7 @@ def compress_file(
     filepath = Path(filepath)
     if compression not in ["gz", "bz2"]:
         raise ValueError("Supported compression formats are 'gz' and 'bz2'.")
-    if filepath.suffix.lower() != f".{compression}":
+    if filepath.suffix.lower() != f".{compression}" and not filepath.is_symlink():
         with open(filepath, "rb") as f_in, zopen(
             f"{filepath}.{compression}", "wb"
         ) as f_out:

--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -29,7 +29,7 @@ def copy_r(src: str | Path, dst: str | Path) -> None:
     for f in os.listdir(abssrc):
         if fpath.is_symlink():
             continue
-        if fpath.is_file():
+        elif fpath.is_file():
             shutil.copy(fpath, absdst)
         elif str(fpath) not in str(absdst):
             copy_r(fpath, Path(absdst, f))

--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -27,8 +27,9 @@ def copy_r(src: str | Path, dst: str | Path) -> None:
     absdst = dst.resolve()
     os.makedirs(absdst, exist_ok=True)
     for f in os.listdir(abssrc):
-        fpath = Path(abssrc, f)
-        if Path(fpath).is_file():
+        if fpath.is_symlink():
+            continue
+        if fpath.is_file():
             shutil.copy(fpath, absdst)
         elif str(fpath) not in str(absdst):
             copy_r(fpath, Path(absdst, f))

--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -27,6 +27,7 @@ def copy_r(src: str | Path, dst: str | Path) -> None:
     absdst = dst.resolve()
     os.makedirs(absdst, exist_ok=True)
     for f in os.listdir(abssrc):
+        fpath = Path(abssrc, f)
         if fpath.is_symlink():
             continue
         elif fpath.is_file():

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -29,7 +29,8 @@ class TestCopyR:
         os.mkdir(os.path.join(test_dir, "cpr_src", "sub"))
         with open(os.path.join(test_dir, "cpr_src", "sub", "testr"), "w") as f:
             f.write("what2")
-        Path(test_dir, "symlink1").symlink_to(test_dir, "cpr_src", "test")
+        if os.name != "nt":
+            Path(test_dir, "symlink1").symlink_to(Path(test_dir, "cpr_src", "test"))
 
     def test_recursive_copy_and_compress(self):
         copy_r(os.path.join(test_dir, "cpr_src"), os.path.join(test_dir, "cpr_dst"))

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -31,7 +31,10 @@ class TestCopyR:
             f.write("what2")
         symlink_path = Path(test_dir, "cpr_src", "test")
         if os.name != "nt":
-            os.symlink(os.path.join(test_dir, "cpr_src", "test"), os.path.join(test_dir, "cpr_src"))
+            os.symlink(
+                os.path.join(test_dir, "cpr_src", "test"),
+                os.path.join(test_dir, "cpr_src"),
+            )
 
     def test_recursive_copy_and_compress(self):
         copy_r(os.path.join(test_dir, "cpr_src"), os.path.join(test_dir, "cpr_dst"))

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -29,7 +29,6 @@ class TestCopyR:
         os.mkdir(os.path.join(test_dir, "cpr_src", "sub"))
         with open(os.path.join(test_dir, "cpr_src", "sub", "testr"), "w") as f:
             f.write("what2")
-        symlink_path = Path(test_dir, "cpr_src", "test")
         if os.name != "nt":
             os.symlink(
                 os.path.join(test_dir, "cpr_src", "test"),

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -29,6 +29,7 @@ class TestCopyR:
         os.mkdir(os.path.join(test_dir, "cpr_src", "sub"))
         with open(os.path.join(test_dir, "cpr_src", "sub", "testr"), "w") as f:
             f.write("what2")
+        Path(test_dir, "symlink1").symlink_to(test_dir, "cpr_src")
 
     def test_recursive_copy_and_compress(self):
         copy_r(os.path.join(test_dir, "cpr_src"), os.path.join(test_dir, "cpr_dst"))

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -29,8 +29,9 @@ class TestCopyR:
         os.mkdir(os.path.join(test_dir, "cpr_src", "sub"))
         with open(os.path.join(test_dir, "cpr_src", "sub", "testr"), "w") as f:
             f.write("what2")
-        if os.name != "nt" and not Path("test_dir", "symlink1").exists():
-            Path(test_dir, "symlink1").symlink_to(Path(test_dir, "cpr_src", "test"))
+        symlink_path = Path(test_dir, "cpr_src", "test")
+        if os.name != "nt" and not symlink_path.exists():
+            Path(test_dir, "symlink1").symlink_to(symlink_path)
 
     def test_recursive_copy_and_compress(self):
         copy_r(os.path.join(test_dir, "cpr_src"), os.path.join(test_dir, "cpr_dst"))

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -29,7 +29,7 @@ class TestCopyR:
         os.mkdir(os.path.join(test_dir, "cpr_src", "sub"))
         with open(os.path.join(test_dir, "cpr_src", "sub", "testr"), "w") as f:
             f.write("what2")
-        Path(test_dir, "symlink1").symlink_to(test_dir, "cpr_src")
+        Path(test_dir, "symlink1").symlink_to(test_dir, "cpr_src", "test")
 
     def test_recursive_copy_and_compress(self):
         copy_r(os.path.join(test_dir, "cpr_src"), os.path.join(test_dir, "cpr_dst"))

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -29,7 +29,7 @@ class TestCopyR:
         os.mkdir(os.path.join(test_dir, "cpr_src", "sub"))
         with open(os.path.join(test_dir, "cpr_src", "sub", "testr"), "w") as f:
             f.write("what2")
-        if os.name != "nt":
+        if os.name != "nt" and not Path("test_dir", "symlink1").exists():
             Path(test_dir, "symlink1").symlink_to(Path(test_dir, "cpr_src", "test"))
 
     def test_recursive_copy_and_compress(self):

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -30,8 +30,8 @@ class TestCopyR:
         with open(os.path.join(test_dir, "cpr_src", "sub", "testr"), "w") as f:
             f.write("what2")
         symlink_path = Path(test_dir, "cpr_src", "test")
-        if os.name != "nt" and not symlink_path.exists():
-            Path(test_dir, "symlink1").symlink_to(symlink_path)
+        if os.name != "nt":
+            os.symlink(os.path.join(test_dir, "cpr_src", "test"), os.path.join(test_dir, "cpr_src"))
 
     def test_recursive_copy_and_compress(self):
         copy_r(os.path.join(test_dir, "cpr_src"), os.path.join(test_dir, "cpr_dst"))

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -33,7 +33,7 @@ class TestCopyR:
         if os.name != "nt":
             os.symlink(
                 os.path.join(test_dir, "cpr_src", "test"),
-                os.path.join(test_dir, "cpr_src"),
+                os.path.join(test_dir, "cpr_src", "mysymlink"),
             )
 
     def test_recursive_copy_and_compress(self):


### PR DESCRIPTION
If a symlink is present when using `copy_r`, you'll get into an infinite, recursive loop of copying. This PR ignores symlinks when using `copy_r`.

I also fixed a related issue with `compress_file`.