### PR TITLE
Add an optional arg `deadline` to `dev.deprecated` to raise warning after deadline 

### DIFF
--- a/docs/monty.dev.md
+++ b/docs/monty.dev.md
@@ -26,19 +26,6 @@ with a possible replacement.
 * **Returns**
   Original function, but with a warning to use the updated class.
 
-## monty.dev.get_ncpus()
-
-**NOTE**: If you are using Python >= 2.7, multiprocessing.cpu_count() already
-provides the number of CPUs. In fact, this is the first method tried.
-The purpose of this function is to cater to old Python versions that
-still exist on many Linux style clusters.
-
-Number of virtual or physical CPUs on this system, i.e.
-user/real as output by time(1) when called with an optimally scaling
-userspace-only program. Return -1 if ncpus cannot be detected. Taken from:
-[http://stackoverflow.com/questions/1006289/how-to-find-out-the-number-of](http://stackoverflow.com/questions/1006289/how-to-find-out-the-number-of)-
-cpus-in-python
-
 ## monty.dev.install_excepthook(hook_type=’color’, \*\*kwargs)
 
 This function replaces the original python traceback with an improved

--- a/docs/monty.dev.md
+++ b/docs/monty.dev.md
@@ -18,7 +18,7 @@ with a possible replacement.
   * **replacement** (*callable*) – A replacement class or method.
   * **message** (*str*) – A warning message to be displayed.
   * **category** (*Warning*) – Choose the category of the warning to issue. Defaults
-    to FutureWarning. Another choice can be DeprecationWarning. NOte that
+    to FutureWarning. Another choice can be DeprecationWarning. Note that
     FutureWarning is meant for end users and is always shown unless silenced.
     DeprecationWarning is meant for developers and is never shown unless
     python is run in developmental mode or the filter is changed. Make

--- a/docs/monty.md
+++ b/docs/monty.md
@@ -44,7 +44,6 @@ useful design patterns such as singleton and cached_class, and many more.
   * `singleton()`
 * [monty.dev module](monty.dev.md)
   * `deprecated()`
-  * `get_ncpus()`
   * `install_excepthook()`
   * `requires`
 * [monty.fnmatch module](monty.fnmatch.md)

--- a/monty/dev.py
+++ b/monty/dev.py
@@ -72,7 +72,7 @@ def deprecated(
         return wrapped
 
     # Raise a CI error after removal deadline
-    if deadline is not None and "CI" in os.environ and datetime.now() > deadline:
+    if deadline is not None and os.getenv("CI") and datetime.now() > deadline:
         raise DeprecationWarning(
             "This function should have been removed on {deadline:%Y-%m-%d}."
         )

--- a/monty/dev.py
+++ b/monty/dev.py
@@ -27,7 +27,7 @@ def deprecated(
         replacement (callable): A replacement class or method.
         message (str): A warning message to be displayed.
         deadline (Optional[tuple[int, int, int]]): Optional deadline for removal
-            of the old function/class, in format (yyyy, MM, dd). A CI error would
+            of the old function/class, in format (yyyy, MM, dd). A CI warning would
             be raised after this date.
         category (Warning): Choose the category of the warning to issue. Defaults
             to FutureWarning. Another choice can be DeprecationWarning. Note that
@@ -76,7 +76,7 @@ def deprecated(
 
         return wrapped
 
-    # Raise a CI error after removal deadline
+    # Raise a CI warning after removal deadline
     if deadline is None:
         _deadline = None
 

--- a/monty/dev.py
+++ b/monty/dev.py
@@ -48,7 +48,7 @@ def deprecated(
         msg = f"{old.__name__} is deprecated"
 
         if deadline is not None:
-            msg += f", and would be removed on {deadline.strftime('%Y-%m-%d')}\n"
+            msg += f", and will be removed on {deadline:%Y-%m-%d}\n"
 
         if replacement is not None:
             if isinstance(replacement, property):
@@ -73,7 +73,9 @@ def deprecated(
 
     # Raise a CI error after removal deadline
     if deadline is not None and "CI" in os.environ and datetime.now() > deadline:
-        raise RuntimeError("This function should have been removed.")
+        raise DeprecationWarning(
+            "This function should have been removed on {deadline:%Y-%m-%d}."
+        )
 
     return deprecated_decorator
 

--- a/monty/dev.py
+++ b/monty/dev.py
@@ -41,9 +41,7 @@ def deprecated(
     """
 
     def _convert_date(date: tuple[int, int, int]) -> datetime:
-        """Convert a date in int tuple for datetime type.
-        Expect the date in (yyyy, MM, dd) format.
-        """
+        """Convert date as int tuple (yyyy, MM, dd) to datetime type."""
         return datetime(*date)
 
     def craft_message(

--- a/monty/dev.py
+++ b/monty/dev.py
@@ -7,11 +7,16 @@ import functools
 import logging
 import sys
 import warnings
+from typing import Callable, Optional, Type
 
 logger = logging.getLogger(__name__)
 
 
-def deprecated(replacement=None, message=None, category=FutureWarning):
+def deprecated(
+    replacement: Optional[Callable] = None,
+    message: Optional[str] = None,
+    category: Type[Warning] = FutureWarning,
+):
     """
     Decorator to mark classes or functions as deprecated, with a possible replacement.
 
@@ -19,7 +24,7 @@ def deprecated(replacement=None, message=None, category=FutureWarning):
         replacement (callable): A replacement class or method.
         message (str): A warning message to be displayed.
         category (Warning): Choose the category of the warning to issue. Defaults
-            to FutureWarning. Another choice can be DeprecationWarning. NOte that
+            to FutureWarning. Another choice can be DeprecationWarning. Note that
             FutureWarning is meant for end users and is always shown unless silenced.
             DeprecationWarning is meant for developers and is never shown unless
             python is run in developmental mode or the filter is changed. Make
@@ -29,7 +34,7 @@ def deprecated(replacement=None, message=None, category=FutureWarning):
         Original function, but with a warning to use the updated class.
     """
 
-    def craft_message(old, replacement, message):
+    def craft_message(old: Callable, replacement: Callable, message: str):
         msg = f"{old.__name__} is deprecated"
         if replacement is not None:
             if isinstance(replacement, property):
@@ -43,7 +48,7 @@ def deprecated(replacement=None, message=None, category=FutureWarning):
             msg += "\n" + message
         return msg
 
-    def deprecated_decorator(old):
+    def deprecated_decorator(old: Callable):
         def wrapped(*args, **kwargs):
             msg = craft_message(old, replacement, message)
             warnings.warn(msg, category=category, stacklevel=2)
@@ -101,7 +106,7 @@ class requires:
         return decorated
 
 
-def install_excepthook(hook_type="color", **kwargs):
+def install_excepthook(hook_type: str = "color", **kwargs):
     """
     This function replaces the original python traceback with an improved
     version from Ipython. Use `color` for colourful traceback formatting,

--- a/monty/dev.py
+++ b/monty/dev.py
@@ -46,7 +46,7 @@ def deprecated(
 
         return datetime(*date)
 
-    def deadline_warning() -> None:
+    def raise_deadline_warning() -> None:
         """Raise CI warning after removal deadline in code owner's repo."""
 
         def _is_in_owner_repo() -> bool:
@@ -121,7 +121,7 @@ def deprecated(
     _deadline = _convert_date(deadline) if deadline is not None else None
 
     # Raise a CI warning after removal deadline
-    deadline_warning()
+    raise_deadline_warning()
 
     return deprecated_decorator
 

--- a/monty/dev.py
+++ b/monty/dev.py
@@ -41,11 +41,6 @@ def deprecated(
         Original function, but with a warning to use the updated class.
     """
 
-    def _convert_date(date: tuple[int, int, int]) -> datetime:
-        """Convert date as int tuple (yyyy, MM, dd) to datetime type."""
-
-        return datetime(*date)
-
     def raise_deadline_warning() -> None:
         """Raise CI warning after removal deadline in code owner's repo."""
 
@@ -117,8 +112,8 @@ def deprecated(
 
         return wrapped
 
-    # Convert deadline to datetime
-    _deadline = _convert_date(deadline) if deadline is not None else None
+    # Convert deadline to datetime type
+    _deadline = datetime(*deadline) if deadline is not None else None
 
     # Raise a CI warning after removal deadline
     raise_deadline_warning()

--- a/monty/dev.py
+++ b/monty/dev.py
@@ -64,8 +64,9 @@ def deprecated(
                 owner_repo = (
                     result.stdout.decode("utf-8")
                     .strip()
-                    .lstrip("git@github.com:")
-                    .rstrip(".git")
+                    .lstrip("https://github.com/")  # https clone
+                    .lstrip("git@github.com:")  # ssh clone
+                    .rstrip(".git")  # ssh clone
                 )
 
                 return owner_repo == os.getenv("GITHUB_REPOSITORY")

--- a/monty/json.py
+++ b/monty/json.py
@@ -328,7 +328,7 @@ class MSONable:
         if core_schema is None:
             raise RuntimeError("Pydantic >= 2.0 is required for validation")
 
-        s = core_schema.general_plain_validator_function(cls.validate_monty_v2)
+        s = core_schema.with_info_plain_validator_function(cls.validate_monty_v2)
 
         return core_schema.json_or_python_schema(json_schema=s, python_schema=s)
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,12 +1,9 @@
 pytest
 pytest-cov
 coverage
-coveralls
 pycodestyle
 mypy
-pydocstyle
 pydantic
-flake8
 black
 pylint
 torch

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -1,6 +1,5 @@
 import unittest
 import warnings
-from datetime import datetime
 
 import pytest
 from monty.dev import deprecated, install_excepthook, requires
@@ -89,7 +88,7 @@ class TestDecorator:
             assert TestClass().classmethod_b() == "b"
 
     def test_deprecated_deadline(self):
-        @deprecated(deadline=datetime(2000, 1, 1))
+        @deprecated(deadline=(2000, 1, 1))
         def func_old():
             pass
 

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -2,32 +2,30 @@ import unittest
 import warnings
 
 import pytest
-
 from monty.dev import deprecated, install_excepthook, requires
 
 
 class TestDecorator:
     def test_deprecated(self):
-        def func_a():
+        def func_replace():
             pass
 
-        @deprecated(func_a, "hello")
-        def func_b():
+        @deprecated(func_replace, "Use func_replace instead")
+        def func_old():
             pass
 
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
             # Trigger a warning.
-            func_b()
-            # Verify some things
+            func_old()
+            # Verify Warning and message
             assert issubclass(w[0].category, FutureWarning)
-            assert "hello" in str(w[0].message)
+            assert "Use func_replace instead" in str(w[0].message)
 
     def test_deprecated_property(self):
-        class a:
-            def __init__(self):
-                pass
+        class TestClass:
+            """A dummy class for tests."""
 
             @property
             def property_a(self):
@@ -46,22 +44,21 @@ class TestDecorator:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
             # Trigger a warning.
-            assert a().property_b == "b"
-            # Verify some things
+            assert TestClass().property_b == "b"
+            # Verify warning type
             assert issubclass(w[-1].category, FutureWarning)
 
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
             # Trigger a warning.
-            assert a().func_a() == "a"
+            assert TestClass().func_a() == "a"
             # Verify some things
             assert issubclass(w[-1].category, FutureWarning)
 
     def test_deprecated_classmethod(self):
-        class A:
-            def __init__(self):
-                pass
+        class TestClass:
+            """A dummy class for tests."""
 
             @classmethod
             def classmethod_a(self):
@@ -76,13 +73,12 @@ class TestDecorator:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
             # Trigger a warning.
-            assert A().classmethod_b() == "b"
+            assert TestClass().classmethod_b() == "b"
             # Verify some things
             assert issubclass(w[-1].category, FutureWarning)
 
-        class A:
-            def __init__(self):
-                pass
+        class TestClass:
+            """A dummy class for tests."""
 
             @classmethod
             def classmethod_a(self):
@@ -94,7 +90,7 @@ class TestDecorator:
                 return "b"
 
         with pytest.warns(DeprecationWarning):
-            assert A().classmethod_b() == "b"
+            assert TestClass().classmethod_b() == "b"
 
     def test_requires(self):
         try:

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -93,11 +93,11 @@ class TestDecorator:
         def func_old():
             pass
 
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as warn_msgs:
             # Trigger a warning.
             func_old()
             # Verify message
-            assert "will be removed on 2000-01-01" in str(w[0].message)
+            assert "will be removed on 2000-01-01" in str(warn_msgs[0].message)
 
     def test_deprecated_deadline_no_warn(self, monkeypatch):
         # Test cases where no warning should be raised
@@ -106,33 +106,33 @@ class TestDecorator:
             pass
 
         # No warn case 1: date before deadline
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as warn_msgs:
             monkeypatch.setattr(
                 datetime, "datetime", lambda: datetime.datetime(1999, 1, 1)
             )
             func_old()
 
-            for warning in w:
+            for warning in warn_msgs:
                 assert "This function should have been removed on" not in str(
                     warning.message
                 )
 
         # No warn case 2: not in CI env
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as warn_msgs:
             monkeypatch.delenv("CI", raising=False)
             func_old()
 
-            for warning in w:
+            for warning in warn_msgs:
                 assert "This function should have been removed on" not in str(
                     warning.message
                 )
 
         # No warn case 3: not in code owner repo
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as warn_msgs:
             monkeypatch.setenv("GITHUB_REPOSITORY", "NONE/NONE")
             func_old()
 
-            for warning in w:
+            for warning in warn_msgs:
                 assert "This function should have been removed on" not in str(
                     warning.message
                 )

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -1,5 +1,6 @@
 import unittest
 import warnings
+from datetime import datetime
 
 import pytest
 from monty.dev import deprecated, install_excepthook, requires
@@ -86,6 +87,17 @@ class TestDecorator:
 
         with pytest.warns(DeprecationWarning):
             assert TestClass().classmethod_b() == "b"
+
+    def test_deprecated_deadline(self):
+        @deprecated(deadline=datetime(2000, 1, 1))
+        def func_old():
+            pass
+
+        with warnings.catch_warnings(record=True) as w:
+            # Trigger a warning.
+            func_old()
+            # Verify message
+            assert "would be removed on 2000-01-01" in str(w[0].message)
 
     def test_requires(self):
         try:

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -100,7 +100,8 @@ class TestDecorator:
             assert "will be removed on 2000-01-01" in str(warn_msgs[0].message)
 
     def test_deprecated_deadline_no_warn(self, monkeypatch):
-        # Test cases where no warning should be raised
+        """Test cases where no warning should be raised."""
+
         @deprecated(deadline=(2000, 1, 1))
         def func_old():
             pass

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -6,17 +6,6 @@ import pytest
 from monty.dev import deprecated, install_excepthook, requires
 
 
-class A:
-    @property
-    def repl_prop(self):
-        pass
-
-    @deprecated(repl_prop)  # type: ignore
-    @property
-    def prop(self):
-        pass
-
-
 class TestDecorator:
     def test_deprecated(self):
         def func_a():

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -97,7 +97,7 @@ class TestDecorator:
             # Trigger a warning.
             func_old()
             # Verify message
-            assert "would be removed on 2000-01-01" in str(w[0].message)
+            assert "will be removed on 2000-01-01" in str(w[0].message)
 
     def test_requires(self):
         try:

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -4,6 +4,9 @@ import warnings
 import pytest
 from monty.dev import deprecated, install_excepthook, requires
 
+# Set all warnings to always be triggered.
+warnings.simplefilter("always")
+
 
 class TestDecorator:
     def test_deprecated(self):
@@ -15,8 +18,6 @@ class TestDecorator:
             pass
 
         with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
             # Trigger a warning.
             func_old()
             # Verify Warning and message
@@ -41,16 +42,12 @@ class TestDecorator:
                 return "a"
 
         with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
             # Trigger a warning.
             assert TestClass().property_b == "b"
             # Verify warning type
             assert issubclass(w[-1].category, FutureWarning)
 
         with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
             # Trigger a warning.
             assert TestClass().func_a() == "a"
             # Verify some things
@@ -70,8 +67,6 @@ class TestDecorator:
                 return "b"
 
         with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
             # Trigger a warning.
             assert TestClass().classmethod_b() == "b"
             # Verify some things

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -6,6 +6,7 @@ import json
 import os
 import pathlib
 from enum import Enum
+from typing import Union
 
 try:
     import numpy as np
@@ -825,7 +826,7 @@ class TestJson:
             a: LimitedMSONClass
 
         class ModelWithUnion(BaseModel):
-            a: LimitedMSONClass | dict
+            a: Union[LimitedMSONClass, dict]
 
         limited_dict = jsanitize(ModelWithLimited(a=LimitedMSONClass(1)), strict=True)
         assert ModelWithLimited.model_validate(limited_dict)


### PR DESCRIPTION
### Major changes:

- Add an optional arg `deadline` for declaration of the deadline, and raise a CI warning pass that date 
(thanks @janosh for the helpful discussion in https://github.com/materialsproject/pymatgen/pull/3656#discussion_r1502199179)
- Add type hints

### Minor tweaks:

- Remove unused deps in `requirements-ci.txt` (let me know if they're intended otherwise)
- Minor clean up of `test_dev` unit test file (removed a random `Class A` unused anywhere)
- Replace deprecated `general_plain_validator_function` from `monty/json.py`

### Side notes:

- running `pytest` on `test_tempfile.py` seems to modify `test_files/3000_lines.txt.gz` in place, this should not happen.
