### PR TITLE
Add optional arg `target_dir` in `compress_file` and `decompress_file` to allow specify target path

### DIFF
--- a/monty/io.py
+++ b/monty/io.py
@@ -17,7 +17,7 @@ from typing import IO, Generator, Union
 
 
 def zopen(filename: Union[str, Path], *args, **kwargs) -> IO:
-    r"""
+    """
     This function wraps around the bz2, gzip, lzma, xz and standard python's open
     function to deal intelligently with bzipped, gzipped or standard text
     files.

--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -6,7 +6,7 @@ import shutil
 import warnings
 from gzip import GzipFile
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 
 from .io import zopen
 
@@ -66,7 +66,7 @@ def gzip_dir(path: str | Path, compresslevel: int = 6) -> None:
 def compress_file(
     filepath: str | Path,
     compression: Literal["gz", "bz2"] = "gz",
-    target_dir: str | Path = "",
+    target_dir: Optional[str | Path] = None,
 ) -> None:
     """
     Compresses a file with the correct extension. Functions like standard
@@ -78,16 +78,16 @@ def compress_file(
         compression (str): A compression mode. Valid options are "gz" or
             "bz2". Defaults to "gz".
         target_dir (str | Path): An optional target dir where the result compressed
-            file would be stored. Defaults to in-place compression.
+            file would be stored. Defaults to None for in-place compression.
     """
     filepath = Path(filepath)
-    target_dir = str(target_dir)
+    target_dir = Path(target_dir) if target_dir is not None else None
 
     if compression not in {"gz", "bz2"}:
         raise ValueError("Supported compression formats are 'gz' and 'bz2'.")
 
     if filepath.suffix.lower() != f".{compression}" and not filepath.is_symlink():
-        if target_dir:
+        if target_dir is not None:
             os.makedirs(target_dir, exist_ok=True)
             compressed_file = os.path.join(
                 target_dir, f"{os.path.basename(filepath)}.{compression}"
@@ -121,7 +121,9 @@ def compress_dir(path: str | Path, compression: Literal["gz", "bz2"] = "gz") -> 
     return None
 
 
-def decompress_file(filepath: str | Path, target_dir: str | Path = "") -> str | None:
+def decompress_file(
+    filepath: str | Path, target_dir: Optional[str | Path] = None
+) -> str | None:
     """
     Decompresses a file with the correct extension. Automatically detects
     gz, bz2 or z extension.
@@ -129,17 +131,17 @@ def decompress_file(filepath: str | Path, target_dir: str | Path = "") -> str | 
     Args:
         filepath (str | Path): Path to file.
         target_dir (str | Path): An optional target dir where the result decompressed
-            file would be stored. Defaults to in-place decompression.
+            file would be stored. Defaults to None for in-place decompression.
 
     Returns:
         str | None: The decompressed file path, None if no operation.
     """
     filepath = Path(filepath)
+    target_dir = Path(target_dir) if target_dir is not None else None
     file_ext = filepath.suffix
-    target_dir = str(target_dir)
 
     if file_ext.lower() in {".bz2", ".gz", ".z"} and filepath.is_file():
-        if target_dir:
+        if target_dir is not None:
             os.makedirs(target_dir, exist_ok=True)
             decompressed_file = os.path.join(
                 target_dir, os.path.basename(str(filepath)).removesuffix(file_ext)

--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -88,6 +88,7 @@ def compress_file(
 
     if filepath.suffix.lower() != f".{compression}" and not filepath.is_symlink():
         if target_dir:
+            os.makedirs(target_dir, exist_ok=True)
             compressed_file = os.path.join(
                 target_dir, f"{os.path.basename(filepath)}.{compression}"
             )
@@ -139,6 +140,7 @@ def decompress_file(filepath: str | Path, target_dir: str | Path = "") -> str | 
 
     if file_ext.lower() in {".bz2", ".gz", ".z"} and filepath.is_file():
         if target_dir:
+            os.makedirs(target_dir, exist_ok=True)
             decompressed_file = os.path.join(
                 target_dir, os.path.basename(str(filepath)).removesuffix(file_ext)
             )

--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -90,7 +90,7 @@ def compress_file(
     if filepath.suffix.lower() != f".{compression}" and not filepath.is_symlink():
         if target_dir is not None:
             os.makedirs(target_dir, exist_ok=True)
-            compressed_file = target_dir / f"{filepath.name}.{compression}"
+            compressed_file: str | Path = target_dir / f"{filepath.name}.{compression}"
 
         else:
             compressed_file = f"{str(filepath)}.{compression}"
@@ -142,7 +142,9 @@ def decompress_file(
     if file_ext.lower() in {".bz2", ".gz", ".z"} and filepath.is_file():
         if target_dir is not None:
             os.makedirs(target_dir, exist_ok=True)
-            decompressed_file = target_dir / filepath.name.removesuffix(file_ext)
+            decompressed_file: str | Path = target_dir / filepath.name.removesuffix(
+                file_ext
+            )
         else:
             decompressed_file = str(filepath).removesuffix(file_ext)
 

--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -81,17 +81,19 @@ def compress_file(
             file would be stored. Defaults to in-place compression.
     """
     filepath = Path(filepath)
+    target_dir = str(target_dir)
 
     if compression not in {"gz", "bz2"}:
         raise ValueError("Supported compression formats are 'gz' and 'bz2'.")
 
     if filepath.suffix.lower() != f".{compression}" and not filepath.is_symlink():
         if target_dir:
-            compressed_file = Path(target_dir) / filepath.with_suffix(
-                filepath.suffix + f".{compression}"
+            compressed_file = os.path.join(
+                target_dir, f"{os.path.basename(filepath)}.{compression}"
             )
+
         else:
-            compressed_file = filepath.with_suffix(filepath.suffix + f".{compression}")
+            compressed_file = f"{str(filepath)}.{compression}"
 
         with open(filepath, "rb") as f_in, zopen(compressed_file, "wb") as f_out:
             f_out.writelines(f_in)
@@ -133,14 +135,15 @@ def decompress_file(filepath: str | Path, target_dir: str | Path = "") -> str | 
     """
     filepath = Path(filepath)
     file_ext = filepath.suffix
+    target_dir = str(target_dir)
 
     if file_ext.lower() in {".bz2", ".gz", ".z"} and filepath.is_file():
         if target_dir:
-            decompressed_file = Path(target_dir) / Path(
-                str(filepath).removesuffix(file_ext)
+            decompressed_file = os.path.join(
+                target_dir, os.path.basename(str(filepath)).removesuffix(file_ext)
             )
         else:
-            decompressed_file = Path(str(filepath).removesuffix(file_ext))
+            decompressed_file = str(filepath).removesuffix(file_ext)
 
         with zopen(filepath, "rb") as f_in, open(decompressed_file, "wb") as f_out:
             f_out.writelines(f_in)

--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -90,9 +90,7 @@ def compress_file(
     if filepath.suffix.lower() != f".{compression}" and not filepath.is_symlink():
         if target_dir is not None:
             os.makedirs(target_dir, exist_ok=True)
-            compressed_file = os.path.join(
-                target_dir, f"{os.path.basename(filepath)}.{compression}"
-            )
+            compressed_file = target_dir / f"{filepath.name}.{compression}"
 
         else:
             compressed_file = f"{str(filepath)}.{compression}"
@@ -144,9 +142,7 @@ def decompress_file(
     if file_ext.lower() in {".bz2", ".gz", ".z"} and filepath.is_file():
         if target_dir is not None:
             os.makedirs(target_dir, exist_ok=True)
-            decompressed_file = os.path.join(
-                target_dir, os.path.basename(str(filepath)).removesuffix(file_ext)
-            )
+            decompressed_file = target_dir / filepath.name.removesuffix(file_ext)
         else:
             decompressed_file = str(filepath).removesuffix(file_ext)
 

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -114,7 +114,6 @@ class TestCompressFileDir:
             with open(fname) as f:
                 assert f.read() == "hello world"
 
-
     def teardown_method(self):
         os.remove(os.path.join(test_dir, "tempfile"))
 

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -95,8 +95,6 @@ class TestCompressFileDir:
         target_dir = os.path.join(test_dir, "temp_target_dir")
 
         for fmt in ["gz", "bz2"]:
-            os.makedirs(target_dir)
-
             compress_file(fname, fmt, target_dir)
             compressed_file_path = os.path.join(
                 target_dir, f"{os.path.basename(fname)}.{fmt}"
@@ -111,11 +109,11 @@ class TestCompressFileDir:
 
             # Reset temp file position
             shutil.move(decompressed_file_path, fname)
+            shutil.rmtree(target_dir)
 
             with open(fname) as f:
                 assert f.read() == "hello world"
 
-            shutil.rmtree(target_dir)
 
     def teardown_method(self):
         os.remove(os.path.join(test_dir, "tempfile"))

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -69,6 +69,7 @@ class TestCompressFileDir:
 
     def test_compress_and_decompress_file(self):
         fname = os.path.join(test_dir, "tempfile")
+
         for fmt in ["gz", "bz2"]:
             compress_file(fname, fmt)
             assert os.path.exists(fname + "." + fmt)
@@ -76,9 +77,11 @@ class TestCompressFileDir:
             decompress_file(fname + "." + fmt)
             assert os.path.exists(fname)
             assert not os.path.exists(fname + "." + fmt)
+
         with open(fname) as f:
             txt = f.read()
             assert txt == "hello world"
+
         with pytest.raises(ValueError):
             compress_file("whatever", "badformat")
 
@@ -86,6 +89,22 @@ class TestCompressFileDir:
         assert decompress_file("non-existent") is None
         assert decompress_file("non-existent.gz") is None
         assert decompress_file("non-existent.bz2") is None
+
+    def test_compress_and_decompress_with_target_dir(self):
+        fname = os.path.join(test_dir, "tempfile")
+        target_dir = "."
+
+        for fmt in ["gz", "bz2"]:
+            compress_file(fname, fmt, target_dir)
+            assert os.path.exists(fname + "." + fmt)
+            assert not os.path.exists(fname)
+            decompress_file(fname + "." + fmt, target_dir)
+            assert os.path.exists(fname)
+            assert not os.path.exists(fname + "." + fmt)
+
+        with open(fname) as f:
+            txt = f.read()
+            assert txt == "hello world"
 
     def teardown_method(self):
         os.remove(os.path.join(test_dir, "tempfile"))


### PR DESCRIPTION
## Summary

- Add optional arg `target_dir` in `compress_file` and `decompress_file` to allow specify target path, to close #632.
- Minor docstring cleanups.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an option to specify the target directory for compressing and decompressing files, enhancing user control over file storage locations.

- **Refactor**
	- Removed an unused docstring to improve code clarity.

- **Tests**
	- Added tests for the new target directory feature in file compression and decompression.
	- Improved existing tests for better reliability and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->