### PR TITLE
Make `jsanitize(recursive_msonable=True)` respect duck typing

### DIFF
--- a/monty/itertools.py
+++ b/monty/itertools.py
@@ -1,6 +1,7 @@
 """
 Additional tools for iteration.
 """
+
 import itertools
 
 try:

--- a/monty/json.py
+++ b/monty/json.py
@@ -713,7 +713,7 @@ def jsanitize(
         except TypeError:
             pass
 
-    if recursive_msonable and isinstance(obj, MSONable):
+    if recursive_msonable and hasattr(obj, "as_dict") and callable(obj.as_dict):
         return obj.as_dict()
 
     if not strict:

--- a/monty/json.py
+++ b/monty/json.py
@@ -713,8 +713,11 @@ def jsanitize(
         except TypeError:
             pass
 
-    if recursive_msonable and hasattr(obj, "as_dict") and callable(obj.as_dict):
-        return obj.as_dict()
+    if recursive_msonable:
+        try:
+            return obj.as_dict()
+        except AttributeError:
+            pass
 
     if not strict:
         return str(obj)

--- a/monty/operator.py
+++ b/monty/operator.py
@@ -1,6 +1,7 @@
 """
 Useful additional functions for operators
 """
+
 import operator
 
 

--- a/monty/os/path.py
+++ b/monty/os/path.py
@@ -1,6 +1,7 @@
 """
 Path based methods, e.g., which, zpath, etc.
 """
+
 import os
 
 from monty.fnmatch import WildCard

--- a/monty/serialization.py
+++ b/monty/serialization.py
@@ -2,6 +2,7 @@
 This module implements serialization support for common formats such as json
 and yaml.
 """
+
 import json
 import os
 

--- a/monty/shutil.py
+++ b/monty/shutil.py
@@ -1,4 +1,5 @@
 """Copying and zipping utilities. Works on directories mostly."""
+
 from __future__ import annotations
 
 import os

--- a/monty/subprocess.py
+++ b/monty/subprocess.py
@@ -1,6 +1,7 @@
 """
 Calling shell processes.
 """
+
 import shlex
 import threading
 import traceback

--- a/monty/termcolor.py
+++ b/monty/termcolor.py
@@ -20,6 +20,7 @@ Copyright (c) 2008-2011 Volvox Development Team
 
 ANSII Color formatting for output in terminal.
 """
+
 import os
 
 try:

--- a/tasks.py
+++ b/tasks.py
@@ -4,7 +4,6 @@
 Deployment file to facilitate releases of monty.
 """
 
-
 import datetime
 import glob
 import json

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -600,7 +600,7 @@ class TestJson:
         assert clean["world"] is None
         assert json.loads(json.dumps(d)) == json.loads(json.dumps(clean))
 
-        d = {"hello": GoodMSONClass(1, 2, 3)}
+        d = {"hello": GoodMSONClass(1, 2, 3), "test": "hi"}
         with pytest.raises(TypeError):
             json.dumps(d)
         clean = jsanitize(d)
@@ -611,6 +611,7 @@ class TestJson:
         clean_recursive_msonable = jsanitize(d, recursive_msonable=True)
         assert clean_recursive_msonable["hello"]["a"] == 1
         assert clean_recursive_msonable["hello"]["b"] == 2
+        assert clean_recursive_msonable["test"] == "hi"
 
         d = {"dt": datetime.datetime.now()}
         clean = jsanitize(d)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -608,6 +608,7 @@ class TestJson:
         clean_strict = jsanitize(d, strict=True)
         assert clean_strict["hello"]["a"] == 1
         assert clean_strict["hello"]["b"] == 2
+        assert clean_strict["test"] == "hi"
         clean_recursive_msonable = jsanitize(d, recursive_msonable=True)
         assert clean_recursive_msonable["hello"]["a"] == 1
         assert clean_recursive_msonable["hello"]["b"] == 2


### PR DESCRIPTION
"If it looks like a duck and quacks like a duck..."

In this PR, I replace the `isinstance(obj, MSONable)` check with a `try`/`except` on the `.as_dict()` method instead in `jsanitize`. This makes it possible to jsanitize objects that have been patched with `.as_dict()` attributes even if they are not formally inheriting from the `MSONable` class.
