### PR TITLE
Add save and load functionality to MSONable

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -558,9 +558,11 @@ class MontyEncoder(json.JSONEncoder):
         if callable(o) and not isinstance(o, MSONable):
             try:
                 return _serialize_callable(o)
-            except AttributeError:
+            except AttributeError as e:
                 # Some callables may not have instance __name__
-                return self._update_name_object_map(o)
+                if self._track_unserializable_objects:
+                    return self._update_name_object_map(o)
+                raise AttributeError(e)
 
         try:
             if pydantic is not None and isinstance(o, pydantic.BaseModel):

--- a/monty/json.py
+++ b/monty/json.py
@@ -249,6 +249,7 @@ class MSONable:
         pickle_kwargs=None,
         json_kwargs=None,
         return_results=False,
+        strict=True,
     ):
         """Utility that uses the standard tools of MSONable to convert the
         class to json format, but also save it to disk. In addition, this
@@ -275,9 +276,11 @@ class MSONable:
         json_kwargs : dict
             Keyword arguments to pass to json.dump.
         return_results : bool
-            If true, also returns the dictionary to save to disk, as well
+            If True, also returns the dictionary to save to disk, as well
             as the mapping between the object_references and the objects
             themselves.
+        strict : bool
+            If True, will not allow you to overwrite existing files.
 
         Returns
         -------
@@ -297,11 +300,18 @@ class MSONable:
         if json_kwargs is None:
             json_kwargs = {}
 
-        with open(save_dir / "class.json", "w") as outfile:
+        json_path = save_dir / "class.json"
+        pickle_path = save_dir / "class.pkl"
+        if strict and json_path.exists():
+            raise FileExistsError(f"strict is true and file {json_path} exists")
+        if strict and pickle_path.exists():
+            raise FileExistsError(f"strict is true and file {pickle_path} exists")
+
+        with open(json_path, "w") as outfile:
             json.dump(encoded, outfile, **json_kwargs)
         pickle.dump(
             encoder._name_object_map,
-            open(save_dir / "class.pkl", "wb"),
+            open(pickle_path, "wb"),
             **pickle_kwargs,
         )
 

--- a/monty/json.py
+++ b/monty/json.py
@@ -318,6 +318,19 @@ class MSONable:
         if return_results:
             return encoded, encoder._name_object_map
 
+    @classmethod
+    def load(cls, load_dir):
+        load_dir = Path(load_dir)
+
+        json_path = load_dir / "class.json"
+        pickle_path = load_dir / "class.pkl"
+
+        with open(json_path, "r") as infile:
+            d = json.load(infile)
+        name_object_map = pickle.load(open(pickle_path, "rb"))
+        klass = cls.from_dict(d)
+        return klass
+
     def unsafe_hash(self):
         """
         Returns an hash of the current object. This uses a generic but low

--- a/monty/json.py
+++ b/monty/json.py
@@ -139,12 +139,12 @@ class MSONable:
 
         class MSONClass(MSONable):
 
-        def __init__(self, a, b, c, d=1, **kwargs):
-            self.a = a
-            self.b = b
-            self._c = c
-            self._d = d
-            self.kwargs = kwargs
+            def __init__(self, a, b, c, d=1, **kwargs):
+                self.a = a
+                self.b = b
+                self._c = c
+                self._d = d
+                self.kwargs = kwargs
 
     For such classes, you merely need to inherit from MSONable and you do not
     need to implement your own as_dict or from_dict protocol.

--- a/monty/json.py
+++ b/monty/json.py
@@ -270,6 +270,18 @@ class MSONable:
         mkdir : bool
             If True, makes the provided directory, including all parent
             directories.
+        pickle_kwargs : dict
+            Keyword arguments to pass to pickle.dump.
+        json_kwargs : dict
+            Keyword arguments to pass to json.dump.
+        return_results : bool
+            If true, also returns the dictionary to save to disk, as well
+            as the mapping between the object_references and the objects
+            themselves.
+
+        Returns
+        -------
+        None or tuple
         """
 
         save_dir = Path(save_dir)

--- a/monty/json.py
+++ b/monty/json.py
@@ -15,6 +15,7 @@ from hashlib import sha1
 from importlib import import_module
 from inspect import getfullargspec
 from pathlib import Path
+from typing import Any, Dict
 from uuid import UUID, uuid4
 
 try:
@@ -325,6 +326,20 @@ class MSONable:
 
     @classmethod
     def load(cls, load_dir):
+        """Loads a class from a provided {load_dir}/class.json and
+        {load_dir}/class.pkl file (if necessary).
+
+        Parameters
+        ----------
+        load_dir : os.PathLike
+            The directory from which to reload the class from.
+
+        Returns
+        -------
+        MSONable
+            An instance of the class being reloaded.
+        """
+
         load_dir = Path(load_dir)
 
         json_path = load_dir / "class.json"
@@ -462,7 +477,7 @@ class MontyEncoder(json.JSONEncoder):
     """
 
     _track_unserializable_objects = False
-    _name_object_map = {}
+    _name_object_map: Dict[str, Any] = {}
     _index = 0
 
     def default(self, o) -> dict:  # pylint: disable=E0202

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -399,44 +399,30 @@ class TestMSONable:
             "Python",
             **{
                 "cant_serialize_me": GoodNOTMSONClass(
-                    "Hello2",
-                    "World2",
-                    "Python2",
+                    "Hello2", "World2", "Python2", **{"values": []}
                 ),
                 "cant_serialize_me2": [
-                    GoodNOTMSONClass(
-                        "Hello4",
-                        "World4",
-                        "Python4",
-                    ),
-                    GoodNOTMSONClass(
-                        "Hello4",
-                        "World4",
-                        "Python4",
-                    ),
+                    GoodNOTMSONClass("Hello4", "World4", "Python4", **{"values": []}),
+                    GoodNOTMSONClass("Hello4", "World4", "Python4", **{"values": []}),
                 ],
                 "cant_serialize_me3": [
                     {
-                        "tmp": GoodNOTMSONClass(
-                            "Hello5",
-                            "World5",
-                            "Python5",
+                        "tmp": GoodMSONClass(
+                            "Hello5", "World5", "Python5", **{"values": []}
                         ),
                         "tmp2": 2,
                         "tmp3": [1, 2, 3],
                     },
                     {
                         "tmp5": GoodNOTMSONClass(
-                            "aHello5",
-                            "aWorld5",
-                            "aPython5",
+                            "aHello5", "aWorld5", "aPython5", **{"values": []}
                         ),
                         "tmp2": 5,
                         "tmp3": {"test": "test123"},
                     },
                     # Gotta check that if I hide an MSONable class somewhere
                     # it still gets correctly serialized.
-                    {"actually_good": GoodMSONClass("1", "2", "3")},
+                    {"actually_good": GoodMSONClass("1", "2", "3", **{"values": []})},
                 ],
                 "values": [],
             },
@@ -451,7 +437,7 @@ class TestMSONable:
 
         # This should also pass though
         target = tmp_path / "test_dir123"
-        test_good_class.save(target)
+        test_good_class.save(target, json_kwargs={"indent": 4, "sort_keys": True})
 
         # This will fail
         with pytest.raises(FileExistsError):
@@ -459,6 +445,7 @@ class TestMSONable:
 
         # Now check that reloading this, the classes are equal!
         test_good_class2 = GoodMSONClass.load(target)
+
         assert test_good_class == test_good_class2
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -57,6 +57,29 @@ class GoodMSONClass(MSONable):
         )
 
 
+class GoodNOTMSONClass:
+    """Literally the same as the GoodMSONClass, except it does not have
+    the MSONable inheritance!"""
+
+    def __init__(self, a, b, c, d=1, *values, **kwargs):
+        self.a = a
+        self.b = b
+        self._c = c
+        self._d = d
+        self.values = values
+        self.kwargs = kwargs
+
+    def __eq__(self, other):
+        return (
+            self.a == other.a
+            and self.b == other.b
+            and self._c == other._c
+            and self._d == other._d
+            and self.kwargs == other.kwargs
+            and self.values == other.values
+        )
+
+
 class LimitedMSONClass(MSONable):
     """An MSONable class that only accepts a limited number of options"""
 
@@ -366,6 +389,36 @@ class TestMSONable:
 
         f = jsanitize(d, enum_values=True)
         assert f["123"] == "value_a"
+
+    def test_save_load(self, tmp_path):
+        """Tests the save and load serialization methods."""
+
+        test_good_class = GoodMSONClass(
+            "Hello",
+            "World",
+            "Python",
+            cant_serialize_me=GoodNOTMSONClass("Hello2", "World2", "Python2"),
+        )
+
+        # This will pass
+        test_good_class.as_dict()
+
+        # This will fail
+        with pytest.raises(TypeError):
+            test_good_class.to_json()
+
+        # This should also pass though
+        target = tmp_path / "test_dir123"
+        test_good_class.save(target)
+
+        # This will fail
+        with pytest.raises(FileExistsError):
+            test_good_class.save(target, strict=True)
+
+        # Now check that reloading this, the classes are equal!
+        test_good_class2 = GoodMSONClass.load(target)
+
+        assert test_good_class == test_good_class2
 
 
 class TestJson:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -397,7 +397,14 @@ class TestMSONable:
             "Hello",
             "World",
             "Python",
-            cant_serialize_me=GoodNOTMSONClass("Hello2", "World2", "Python2"),
+            **{
+                "cant_serialize_me": GoodNOTMSONClass(
+                    "Hello2",
+                    "World2",
+                    "Python2",
+                ),
+                "values": [],
+            },
         )
 
         # This will pass
@@ -417,8 +424,7 @@ class TestMSONable:
 
         # Now check that reloading this, the classes are equal!
         test_good_class2 = GoodMSONClass.load(target)
-
-        assert test_good_class == test_good_class2
+        assert test_good_class, test_good_class2
 
 
 class TestJson:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -403,6 +403,38 @@ class TestMSONable:
                     "World2",
                     "Python2",
                 ),
+                "cant_serialize_me2": [
+                    GoodNOTMSONClass(
+                        "Hello4",
+                        "World4",
+                        "Python4",
+                    ),
+                    GoodNOTMSONClass(
+                        "Hello4",
+                        "World4",
+                        "Python4",
+                    ),
+                ],
+                "cant_serialize_me3": [
+                    {
+                        "tmp": GoodNOTMSONClass(
+                            "Hello5",
+                            "World5",
+                            "Python5",
+                        ),
+                        "tmp2": 2,
+                        "tmp3": [1, 2, 3],
+                    },
+                    {
+                        "tmp5": GoodNOTMSONClass(
+                            "aHello5",
+                            "aWorld5",
+                            "aPython5",
+                        ),
+                        "tmp2": 5,
+                        "tmp3": {"test": "test123"},
+                    },
+                ],
                 "values": [],
             },
         )

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -434,6 +434,9 @@ class TestMSONable:
                         "tmp2": 5,
                         "tmp3": {"test": "test123"},
                     },
+                    # Gotta check that if I hide an MSONable class somewhere
+                    # it still gets correctly serialized.
+                    {"actually_good": GoodMSONClass("1", "2", "3")},
                 ],
                 "values": [],
             },
@@ -456,7 +459,7 @@ class TestMSONable:
 
         # Now check that reloading this, the classes are equal!
         test_good_class2 = GoodMSONClass.load(target)
-        assert test_good_class, test_good_class2
+        assert test_good_class == test_good_class2
 
 
 class TestJson:


### PR DESCRIPTION
This PR adds feature #653 

In particular, it adds `save` and `load` methods to `MSONable`. These methods are flexible, and hook into the existing decoder and encoders in `monty.json`. They work by replacing any instance of an attribute that cannot be serialized by what is essentially a random hash reference to an object in a pickle file saved next to the json. This is then detected during loading, and swapped out for the object when the classmethod `load` is called.

I'd consider this a WIP for now while I continue to test it. I would love feedback by the maintainers @shyuep


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced serialization and deserialization capabilities with the addition of `save` and `load` methods.
	- Improved handling of unserializable objects in serialization processes.
- **Refactor**
	- Modified the `from_dict` method for improved efficiency and reliability.
- **Tests**
	- Extended testing suite to cover serialization, deserialization, and object equality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->