### PR TITLE
Add missing kwargs in recursive `jsanitize` calls (and remove table tennis references in `pyproject.toml` 😅)

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -849,13 +849,13 @@ def jsanitize(
 
     if isinstance(obj, (list, tuple)):
         return [
-            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values)
+            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values, recursive_msonable=recursive_msonable)
             for i in obj
         ]
 
     if np is not None and isinstance(obj, np.ndarray):
         return [
-            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values)
+            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values, recursive_msonable=recursive_msonable)
             for i in obj.tolist()
         ]
 

--- a/monty/json.py
+++ b/monty/json.py
@@ -849,13 +849,25 @@ def jsanitize(
 
     if isinstance(obj, (list, tuple)):
         return [
-            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values, recursive_msonable=recursive_msonable)
+            jsanitize(
+                i,
+                strict=strict,
+                allow_bson=allow_bson,
+                enum_values=enum_values,
+                recursive_msonable=recursive_msonable,
+            )
             for i in obj
         ]
 
     if np is not None and isinstance(obj, np.ndarray):
         return [
-            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values, recursive_msonable=recursive_msonable)
+            jsanitize(
+                i,
+                strict=strict,
+                allow_bson=allow_bson,
+                enum_values=enum_values,
+                recursive_msonable=recursive_msonable,
+            )
             for i in obj.tolist()
         ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ authors = [
 description = "Monty is the missing complement to Python."
 readme = "README.md"
 requires-python = ">=3.9"
-keywords = ["usatt", "table tennis"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
In `jsanitize`, there are some recursive calls to `jsanitize` where all the user-supplied keyword arguments need to be retained for internal consistency. There were two instances missing `recursive_msonable=recursive_msonable` arguments that have now been added.

Also, I removed the following keywords from `pyproject.toml`: keywords = ["usatt", "table tennis"]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Removed specific keywords related to "usatt" and "table tennis" from the `pyproject.toml` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->