### PR TITLE
Fix missing kwargs in internal calls of `jsanitize`

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -680,12 +680,12 @@ def jsanitize(
         return obj
     if isinstance(obj, (list, tuple)):
         return [
-            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values)
+            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values, recursive_msonable=recursive_msonable)
             for i in obj
         ]
     if np is not None and isinstance(obj, np.ndarray):
         return [
-            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values)
+            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values, recursive_msonable=recursive_msonable)
             for i in obj.tolist()
         ]
     if np is not None and isinstance(obj, np.generic):

--- a/monty/json.py
+++ b/monty/json.py
@@ -680,12 +680,24 @@ def jsanitize(
         return obj
     if isinstance(obj, (list, tuple)):
         return [
-            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values, recursive_msonable=recursive_msonable)
+            jsanitize(
+                i,
+                strict=strict,
+                allow_bson=allow_bson,
+                enum_values=enum_values,
+                recursive_msonable=recursive_msonable,
+            )
             for i in obj
         ]
     if np is not None and isinstance(obj, np.ndarray):
         return [
-            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values, recursive_msonable=recursive_msonable)
+            jsanitize(
+                i,
+                strict=strict,
+                allow_bson=allow_bson,
+                enum_values=enum_values,
+                recursive_msonable=recursive_msonable,
+            )
             for i in obj.tolist()
         ]
     if np is not None and isinstance(obj, np.generic):


### PR DESCRIPTION
Identical to #657.

@shyuep, the rollback also reverted my minor but important fix to `jsanitize`. I reinstated it here. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Improved the JSON sanitization process to handle objects in lists or NumPy arrays more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->