### PR TITLE
Support jsanitize-ing 0D numpy arrays

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -690,16 +690,19 @@ def jsanitize(
             for i in obj
         ]
     if np is not None and isinstance(obj, np.ndarray):
-        return [
-            jsanitize(
-                i,
-                strict=strict,
-                allow_bson=allow_bson,
-                enum_values=enum_values,
-                recursive_msonable=recursive_msonable,
-            )
-            for i in obj.tolist()
-        ]
+        try:       
+            return [
+                jsanitize(
+                    i,
+                    strict=strict,
+                    allow_bson=allow_bson,
+                    enum_values=enum_values,
+                    recursive_msonable=recursive_msonable,
+                )
+                for i in obj.tolist()
+            ]
+        except TypeError:
+            return obj.tolist()
     if np is not None and isinstance(obj, np.generic):
         return obj.item()
     if _check_type(

--- a/monty/json.py
+++ b/monty/json.py
@@ -690,7 +690,7 @@ def jsanitize(
             for i in obj
         ]
     if np is not None and isinstance(obj, np.ndarray):
-        try:       
+        try:
             return [
                 jsanitize(
                     i,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -576,7 +576,7 @@ class TestJson:
         d = jsanitize(x, strict=True)
         assert isinstance(d["energies"][0], float)
 
-        x = {"energy": [np.array(-1.0)]}
+        x = {"energy": np.array(-1.0)}
         d = jsanitize(x, strict=True)
         assert isinstance(d["energy"], float)
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -576,6 +576,10 @@ class TestJson:
         d = jsanitize(x, strict=True)
         assert isinstance(d["energies"][0], float)
 
+        x = {"energy": [np.array(-1.0)]}
+        d = jsanitize(x, strict=True)
+        assert isinstance(d["energy"], float)
+
         # Test data nested in a class
         x = np.array([[1 + 1j, 2 + 1j], [3 + 1j, 4 + 1j]], dtype="complex64")
         cls = ClassContainingNumpyArray(np_a={"a": [{"b": x}]})


### PR DESCRIPTION
Closes #668 by adding support for jsanitize-ing 0D numpy arrays.
