### PR TITLE
Fix internal `jsanitize` calls again

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -895,12 +895,12 @@ def jsanitize(
         return obj
     if isinstance(obj, (list, tuple)):
         return [
-            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values)
+            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values, recursive_msonable=recursive_msonable)
             for i in obj
         ]
     if np is not None and isinstance(obj, np.ndarray):
         return [
-            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values)
+            jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values, recursive_msonable=recursive_msonable)
             for i in obj.tolist()
         ]
     if np is not None and isinstance(obj, np.generic):


### PR DESCRIPTION
In #670, the `recursive_msonable` keyword argument was removed from the internal `jsanitize` calls. I have patched it back.
