### PR TITLE
Add another regression test for `recursive_msonable` behavior

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -24,6 +24,11 @@ except ImportError:
     torch = None
 
 try:
+    import pydantic
+except ImportError:
+    pydantic = None
+
+try:
     from bson.objectid import ObjectId
 except ImportError:
     ObjectId = None
@@ -739,6 +744,13 @@ class TestJson:
         assert clean_recursive_msonable["hello"]["b"] == 2
         assert clean_recursive_msonable["test"] == "hi"
 
+        d = {"hello": [GoodMSONClass(1, 2, 3), "test"], "test": "hi"}
+        clean_recursive_msonable = jsanitize(d, recursive_msonable=True)
+        assert clean_recursive_msonable["hello"][0]["a"] == 1
+        assert clean_recursive_msonable["hello"][0]["b"] == 2
+        assert clean_recursive_msonable["hello"][0]["c"] == 3
+        assert clean_recursive_msonable["hello"][1] == "test"
+
         d = {"dt": datetime.datetime.now()}
         clean = jsanitize(d)
         assert isinstance(clean["dt"], str)
@@ -866,6 +878,7 @@ class TestJson:
             }
         }
 
+    @pytest.mark.skipif(pydantic is None, reason="pydantic not present")
     def test_pydantic_integrations(self):
         from pydantic import BaseModel, ValidationError
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -758,6 +758,7 @@ class TestJson:
         assert clean_recursive_msonable["hello"][0]["a"] == 1
         assert clean_recursive_msonable["hello"][0]["b"] == 2
         assert clean_recursive_msonable["hello"][0]["c"] == 3
+        assert clean_recursive_msonable["hello"][1] == "test"
         assert clean_recursive_msonable["test"] == "hi"
 
         d = {"dt": datetime.datetime.now()}

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -742,6 +742,7 @@ class TestJson:
         clean_recursive_msonable = jsanitize(d, recursive_msonable=True)
         assert clean_recursive_msonable["hello"]["a"] == 1
         assert clean_recursive_msonable["hello"]["b"] == 2
+        assert clean_recursive_msonable["hello"]["c"] == 3
         assert clean_recursive_msonable["test"] == "hi"
 
         d = {"hello": [GoodMSONClass(1, 2, 3), "test"], "test": "hi"}
@@ -750,6 +751,14 @@ class TestJson:
         assert clean_recursive_msonable["hello"][0]["b"] == 2
         assert clean_recursive_msonable["hello"][0]["c"] == 3
         assert clean_recursive_msonable["hello"][1] == "test"
+        assert clean_recursive_msonable["test"] == "hi"
+
+        d = {"hello": (GoodMSONClass(1, 2, 3), "test"), "test": "hi"}
+        clean_recursive_msonable = jsanitize(d, recursive_msonable=True)
+        assert clean_recursive_msonable["hello"][0]["a"] == 1
+        assert clean_recursive_msonable["hello"][0]["b"] == 2
+        assert clean_recursive_msonable["hello"][0]["c"] == 3
+        assert clean_recursive_msonable["test"] == "hi"
 
         d = {"dt": datetime.datetime.now()}
         clean = jsanitize(d)


### PR DESCRIPTION
This PR adds another regression test for `recursive_msonable` behavior in `jsanitize` to prevent breaking of things in the future.

I also ensured the test suite runs if pydantic isn't installed.
