### PR TITLE
`zpath` return file name without compression suffix if file was already decompressed

### DIFF
--- a/monty/os/path.py
+++ b/monty/os/path.py
@@ -27,7 +27,11 @@ def zpath(filename: str) -> str:
         exists). If filename is not found, the same filename is returned
         unchanged.
     """
-    for ext in ["", ".gz", ".GZ", ".bz2", ".BZ2", ".z", ".Z"]:
+    exts = ("", ".gz", ".GZ", ".bz2", ".BZ2", ".z", ".Z")
+    for ext in exts:
+        filename = filename.removesuffix(ext)
+
+    for ext in exts:
         zfilename = f"{filename}{ext}"
         if os.path.exists(zfilename):
             return zfilename

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
+from monty.io import zopen
 from monty.os import cd, makedirs_p
 from monty.os.path import find_exts, zpath
 
@@ -12,9 +14,17 @@ test_dir = os.path.join(module_dir, "test_files")
 
 
 class TestPath:
-    def test_zpath(self):
-        full_zpath = zpath(os.path.join(test_dir, "myfile_gz"))
-        assert os.path.join(test_dir, "myfile_gz.gz") == full_zpath
+    def test_zpath(self, tmp_path: Path):
+        tmp_gz = tmp_path / "tmp.gz"
+        tmp_gz.touch()
+        ret_path = zpath(str(tmp_gz))
+        assert ret_path == str(tmp_gz)
+
+        tmp_not_bz2 = tmp_path / "tmp_not_bz2"
+        tmp_not_bz2.touch()
+
+        ret_path = zpath(f"{tmp_not_bz2}.bz2")
+        assert ret_path == str(tmp_not_bz2)
 
     def test_find_exts(self):
         assert len(find_exts(module_dir, "py")) >= 18

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -7,25 +7,22 @@ import pytest
 from monty.os import cd, makedirs_p
 from monty.os.path import find_exts, zpath
 
-test_dir = os.path.join(os.path.dirname(__file__), "test_files")
+module_dir = os.path.dirname(__file__)
+test_dir = os.path.join(module_dir, "test_files")
 
 
 class TestPath:
     def test_zpath(self):
-        fullzpath = zpath(os.path.join(test_dir, "myfile_gz"))
-        assert os.path.join(test_dir, "myfile_gz.gz") == fullzpath
+        full_zpath = zpath(os.path.join(test_dir, "myfile_gz"))
+        assert os.path.join(test_dir, "myfile_gz.gz") == full_zpath
 
     def test_find_exts(self):
-        assert len(find_exts(os.path.dirname(__file__), "py")) >= 18
-        assert len(find_exts(os.path.dirname(__file__), "bz2")) == 2
-        assert (
-            len(find_exts(os.path.dirname(__file__), "bz2", exclude_dirs="test_files"))
-            == 0
-        )
-        assert (
-            len(find_exts(os.path.dirname(__file__), "bz2", include_dirs="test_files"))
-            == 2
-        )
+        assert len(find_exts(module_dir, "py")) >= 18
+        assert len(find_exts(module_dir, "bz2")) == 2
+        n_bz2_excl_tests = len(find_exts(module_dir, "bz2", exclude_dirs="test_files"))
+        assert n_bz2_excl_tests == 0
+        n_bz2_w_tests = find_exts(module_dir, "bz2", include_dirs="test_files")
+        assert len(n_bz2_w_tests) == 2
 
 
 class TestCd:


### PR DESCRIPTION
this change addresses the case where `zpath` receives a path with a compression extension (`.gz`, `.bz2`, ...) but only a file without that extension exists, in which case `zpath` now returns the path to the existent uncompressed file (whereas before it would return the input file path as is including the compression extension even though no such file exists)

this will allow `zpath` to serve the purpose of the `get_gzip_or_unzipped ` proposed by @esoteric-ephemera in https://github.com/materialsproject/custodian/pull/333, [specifically here](https://github.com/materialsproject/custodian/pull/333/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R18-R38).