### PR TITLE
Fix (de)serialization `datetime` with timezone information

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -748,6 +748,7 @@ class MontyDecoder(json.JSONDecoder):
                 }:
                     if modname == "datetime" and classname == "datetime":
                         try:
+                            # Remove timezone info in the form of "+xx:00"
                             dt = datetime.datetime.strptime(
                                 d["string"].split("+")[0], "%Y-%m-%d %H:%M:%S.%f"
                             )

--- a/monty/json.py
+++ b/monty/json.py
@@ -766,22 +766,22 @@ class MontyDecoder(json.JSONDecoder):
                     mod = __import__(modname, globals(), locals(), [classname], 0)
                     if hasattr(mod, classname):
                         cls_ = getattr(mod, classname)
-                        d = {k: v for k, v in d.items() if not k.startswith("@")}
+                        data = {k: v for k, v in d.items() if not k.startswith("@")}
                         if hasattr(cls_, "from_dict"):
-                            return cls_.from_dict(d)
+                            return cls_.from_dict(data)
                         if issubclass(cls_, Enum):
                             return cls_(d["value"])
                         if pydantic is not None and issubclass(
                             cls_, pydantic.BaseModel
                         ):  # pylint: disable=E1101
-                            d = {k: self.process_decoded(v) for k, v in d.items()}
+                            d = {k: self.process_decoded(v) for k, v in data.items()}
                             return cls_(**d)
                         if (
                             dataclasses is not None
                             and (not issubclass(cls_, MSONable))
                             and dataclasses.is_dataclass(cls_)
                         ):
-                            d = {k: self.process_decoded(v) for k, v in d.items()}
+                            d = {k: self.process_decoded(v) for k, v in data.items()}
                             return cls_(**d)
 
                 elif torch is not None and modname == "torch" and classname == "Tensor":

--- a/monty/json.py
+++ b/monty/json.py
@@ -749,11 +749,11 @@ class MontyDecoder(json.JSONDecoder):
                     if modname == "datetime" and classname == "datetime":
                         try:
                             dt = datetime.datetime.strptime(
-                                d["string"].rstrip("+00:00"), "%Y-%m-%d %H:%M:%S.%f"
+                                d["string"].split("+")[0], "%Y-%m-%d %H:%M:%S.%f"
                             )
                         except ValueError:
                             dt = datetime.datetime.strptime(
-                                d["string"].rstrip("+00:00"), "%Y-%m-%d %H:%M:%S"
+                                d["string"].split("+")[0], "%Y-%m-%d %H:%M:%S"
                             )
                         return dt
 

--- a/monty/json.py
+++ b/monty/json.py
@@ -749,11 +749,11 @@ class MontyDecoder(json.JSONDecoder):
                     if modname == "datetime" and classname == "datetime":
                         try:
                             dt = datetime.datetime.strptime(
-                                d["string"], "%Y-%m-%d %H:%M:%S.%f"
+                                d["string"].rstrip("+00:00"), "%Y-%m-%d %H:%M:%S.%f"
                             )
                         except ValueError:
                             dt = datetime.datetime.strptime(
-                                d["string"], "%Y-%m-%d %H:%M:%S"
+                                d["string"].rstrip("+00:00"), "%Y-%m-%d %H:%M:%S"
                             )
                         return dt
 

--- a/monty/json.py
+++ b/monty/json.py
@@ -644,7 +644,7 @@ class MontyEncoder(json.JSONEncoder):
 
         try:
             if pydantic is not None and isinstance(o, pydantic.BaseModel):
-                d = o.dict()
+                d = o.model_dump()
             elif (
                 dataclasses is not None
                 and (not issubclass(o.__class__, MSONable))

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -516,6 +516,14 @@ class TestJson:
 
         jsanitize(dt, strict=True)
 
+        # test timezone aware datetime API
+        created_at = datetime.datetime.now(tz=datetime.timezone.utc)
+        data = json.loads(json.dumps(created_at, cls=MontyEncoder))
+
+        created_at_after = MontyDecoder().process_decoded(data)
+
+        assert str(created_at_after) == str(created_at).rstrip("+00:00")
+
     def test_uuid(self):
         from uuid import UUID, uuid4
 


### PR DESCRIPTION
## Summary

- Fix (de)serialization `datetime` with timezone information, to fix #275.
- Replace [deprecated `dict` method with `model_dump`](https://docs.pydantic.dev/2.6/migration/)


#### Alternative one
The following alternative avoids such "hard-coded" timezone info removal, but seems more complicated, not sure which way to go though:
```python
from dateutil import parser


if modname == "datetime" and classname == "datetime":
    try:
        dt = datetime.datetime.strptime(
            parser.parse(d["string"]).strftime(
                "%Y-%m-%d %H:%M:%S.%f"
            ),
            "%Y-%m-%d %H:%M:%S.%f",
        )
    except ValueError:
        dt = datetime.datetime.strptime(
            parser.parse(d["string"]).strftime("%Y-%m-%d %H:%M:%S"),
            "%Y-%m-%d %H:%M:%S",
        )
    return dt

```

#### Alternative two
The following could replace timezone info, but will break if no timezone info is present at all (which thus require a check, might just `split`).

```python
time = str(datetime.datetime.now(datetime.timezone.utc))
print(time)  # 2024-06-27 10:52:45.132087+00:00

dt = datetime.datetime.strptime(time, "%Y-%m-%d %H:%M:%S.%f%z").replace(tzinfo=None)
print(dt)  # 2024-06-27 10:52:45.132087
```
