### PR TITLE
`deprecated` decorator allow `replacement` as string

### DIFF
--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -29,6 +29,18 @@ class TestDecorator:
             assert issubclass(w[0].category, FutureWarning)
             assert "Use func_replace instead" in str(w[0].message)
 
+    def test_deprecated_str_replacement(self):
+        @deprecated("func_replace")
+        def func_old():
+            pass
+
+        with warnings.catch_warnings(record=True) as w:
+            # Trigger a warning.
+            func_old()
+            # Verify Warning and message
+            assert issubclass(w[0].category, FutureWarning)
+            assert "use func_replace instead" in str(w[0].message)
+
     def test_deprecated_property(self):
         class TestClass:
             """A dummy class for tests."""


### PR DESCRIPTION
## Summary

- `deprecated` decorator allow `replacement` as string

Rationale: In some cases, the `replacement` may not be directly accessible from current name space, for example the following where a `property` is marked for deprecation:
```python
class DemoClass:
    def __init__(self, new_property) -> None:
        self.new_property = new_property

    @property
    @deprecated(replacement="new_property")
    def old_property(self):
        return self.new_property
```