### PR TITLE
Make `cached_class` decorated classes picklable

### DIFF
--- a/monty/design_patterns.py
+++ b/monty/design_patterns.py
@@ -102,9 +102,9 @@ def cached_class(cls: type[Klass]) -> type[Klass]:
                 return (cls, args, {})
         raise ValueError("Instance not found in cache")
 
-    cls.__new__ = new_new
-    cls.__init__ = new_init
-    cls.__reduce__ = reduce
+    cls.__new__ = new_new  # type: ignore[method-assign]
+    cls.__init__ = new_init  # type: ignore[method-assign]
+    cls.__reduce__ = reduce  # type: ignore[method-assign]
 
     return cls
 

--- a/monty/design_patterns.py
+++ b/monty/design_patterns.py
@@ -4,9 +4,11 @@ Some common design patterns such as singleton and cached classes.
 
 from __future__ import annotations
 
+import inspect
 import os
 from functools import wraps
-from typing import Hashable, TypeVar
+from typing import Any, Dict, Hashable, Tuple, TypeVar
+from weakref import WeakValueDictionary
 
 
 def singleton(cls):
@@ -35,7 +37,7 @@ def singleton(cls):
 Klass = TypeVar("Klass")
 
 
-def cached_class(klass: type[Klass]) -> type[Klass]:
+def cached_class(cls: type[Klass]) -> type[Klass]:
     """
     Decorator to cache class instances by constructor arguments.
     This results in a class that behaves like a singleton for each
@@ -46,56 +48,65 @@ def cached_class(klass: type[Klass]) -> type[Klass]:
     avoid using this decorator for situations where there are many
     constructor arguments permutations.
 
-    The keywords argument dictionary is converted to a tuple because
-    dicts are mutable; keywords themselves are strings and
-    so are always hashable, but if any arguments (keyword
-    or positional) are non-hashable, that set of arguments
+    If any arguments are non-hashable, that set of arguments
     is not cached.
     """
-    cache: dict[tuple[Hashable, ...], type[Klass]] = {}
+    orig_new = cls.__new__
+    orig_init = cls.__init__
+    cache: WeakValueDictionary = WeakValueDictionary()
 
-    @wraps(klass, assigned=("__name__", "__module__"), updated=())
-    class _decorated(klass):  # type: ignore
-        # The wraps decorator can't do this because __doc__
-        # isn't writable once the class is created
-        __doc__ = klass.__doc__
+    @wraps(orig_new)
+    def new_new(cls, *args: Any, **kwargs: Any) -> Any:
+        # Normalize arguments
+        sig = inspect.signature(orig_init)
+        bound_args = sig.bind(None, *args, **kwargs)
+        bound_args.apply_defaults()
 
-        def __new__(cls, *args, **kwargs):
-            """
-            Pass through.
-            """
-            key = (cls, *args, *tuple(kwargs.items()))
-            try:
-                inst = cache.get(key)
-            except TypeError:
-                # Can't cache this set of arguments
-                inst = key = None
-            if inst is None:
-                # Technically this is cheating, but it works,
-                # and takes care of initializing the instance
-                # (so we can override __init__ below safely);
-                # calling up to klass.__new__ would be the
-                # "official" way to create the instance, but
-                # that raises DeprecationWarning if there are
-                # args or kwargs and klass does not override
-                # __new__ (which most classes don't), because
-                # object.__new__ takes no parameters (and in
-                # Python 3 the warning will become an error)
-                inst = klass(*args, **kwargs)
-                # This makes isinstance and issubclass work
-                # properly
-                inst.__class__ = cls
-                if key is not None:
-                    cache[key] = inst
-            return inst
+        # Remove 'self' from the arguments
+        normalized_args = tuple(bound_args.arguments.values())[1:]
 
-        def __init__(self, *args, **kwargs):
-            # This will be called every time __new__ is
-            # called, so we skip initializing here and do
-            # it only when the instance is created above
-            pass
+        try:
+            key = (cls, normalized_args)
+            if key in cache:
+                return cache[key]
 
-    return _decorated
+            if orig_new is object.__new__:
+                instance = orig_new(cls)
+            else:
+                instance = orig_new(cls, *args, **kwargs)
+
+            orig_init(instance, *args, **kwargs)
+            instance._initialized = True
+            cache[key] = instance
+            return instance
+        except TypeError:
+            # Can't cache this set of arguments
+            if orig_new is object.__new__:
+                instance = orig_new(cls)
+            else:
+                instance = orig_new(cls, *args, **kwargs)
+            orig_init(instance, *args, **kwargs)
+            instance._initialized = True
+            return instance
+
+    @wraps(orig_init)
+    def new_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        if not hasattr(self, "_initialized"):
+            orig_init(self, *args, **kwargs)
+            self._initialized = True
+
+    def reduce(self: Any) -> Tuple[type, Tuple, Dict[str, Any]]:
+        for key, value in cache.items():
+            if value is self:
+                cls, args = key
+                return (cls, args, {})
+        raise ValueError("Instance not found in cache")
+
+    cls.__new__ = new_new
+    cls.__init__ = new_init
+    cls.__reduce__ = reduce
+
+    return cls
 
 
 class NullFile:

--- a/tests/test_design_patterns.py
+++ b/tests/test_design_patterns.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import gc
+import pickle
+import weakref
+from typing import Any
+
+import pytest
+
 from monty.design_patterns import cached_class, singleton
 
 
@@ -39,7 +46,245 @@ class TestCachedClass:
         assert id(a1a) == id(a1b)
         assert id(a1a) != id(a2)
 
-    # def test_pickle(self):
-    #     a = A(2)
-    #     o = pickle.dumps(a)
-    #     assert a == pickle.loads(o)
+    def test_pickle(self):
+        a = A(2)
+        o = pickle.dumps(a)
+        assert a == pickle.loads(o)
+
+
+@cached_class
+class TestClass:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+
+def test_caching():
+    # Test that instances are cached
+    inst1 = TestClass(1)
+    inst2 = TestClass(1)
+    assert inst1 is inst2
+
+    inst3 = TestClass(2)
+    assert inst1 is not inst3
+
+
+def test_picklability():
+    # Test that instances can be pickled and unpickled
+    original = TestClass(42)
+    pickled = pickle.dumps(original)
+    unpickled = pickle.loads(pickled)
+
+    # Check that the unpickled instance has the same value
+    assert original.value == unpickled.value
+
+    # Check that the unpickled instance is the same as a newly created instance
+    new_instance = TestClass(42)
+    assert unpickled is new_instance
+
+
+def test_initialization():
+    init_count = 0
+
+    @cached_class
+    class TestInitClass:
+        def __init__(self):
+            nonlocal init_count
+            init_count += 1
+
+    inst1 = TestInitClass()
+    inst2 = TestInitClass()
+    assert init_count == 1
+
+
+def test_class_identity():
+    # Ensure the decorated class is still recognized as the original class
+    assert isinstance(TestClass(1), TestClass)
+    assert type(TestClass(1)) is TestClass
+
+
+def test_multiple_arguments():
+    @cached_class
+    class MultiArgClass:
+        def __init__(self, a, b, c=3):
+            self.args = (a, b, c)
+
+    inst1 = MultiArgClass(1, 2)
+    inst2 = MultiArgClass(1, 2)
+    inst3 = MultiArgClass(1, 2, 4)
+
+    assert inst1 is inst2
+    assert inst1 is not inst3
+    assert inst1.args == (1, 2, 3)
+    assert inst3.args == (1, 2, 4)
+
+
+def test_different_argument_types():
+    @cached_class
+    class MultiTypeClass:
+        def __init__(self, a, b, c):
+            self.a, self.b, self.c = a, b, c
+
+    inst1 = MultiTypeClass(1, "string", (1, 2))
+    inst2 = MultiTypeClass(1, "string", (1, 2))
+    assert inst1 is inst2
+
+    inst3 = MultiTypeClass(1, "string", [1, 2])  # Unhashable argument
+    assert inst1 is not inst3
+
+
+def test_keyword_arguments():
+    @cached_class
+    class KeywordClass:
+        def __init__(self, a, b, c=3):
+            self.a, self.b, self.c = a, b, c
+
+    inst1 = KeywordClass(1, 2)
+    inst2 = KeywordClass(a=1, b=2)
+    assert inst1 is inst2
+
+    inst3 = KeywordClass(1, 2, 4)
+    assert inst1 is not inst3
+
+
+def test_inheritance_chain():
+    @cached_class
+    class GrandParent:
+        def __init__(self, value):
+            self.value = value
+
+    class Parent(GrandParent):
+        pass
+
+    @cached_class
+    class Child(Parent):
+        pass
+
+    gp1 = GrandParent(1)
+    gp2 = GrandParent(1)
+    assert gp1 is gp2
+
+    p1 = Parent(1)
+    p2 = Parent(1)
+    assert p1 is p2
+    assert p1 is not gp1
+
+    c1 = Child(1)
+    c2 = Child(1)
+    assert c1 is c2
+    assert c1 is not p1
+
+
+def test_memory_management():
+    @cached_class
+    class WeakRefClass:
+        def __init__(self, value):
+            self.value = value
+
+    inst = WeakRefClass(1)
+    weak_ref = weakref.ref(inst)
+
+    del inst
+    gc.collect()
+
+    assert weak_ref() is None
+
+    # Creating a new instance should work
+    new_inst = WeakRefClass(1)
+    assert new_inst.value == 1
+
+
+def test_exception_in_init():
+    init_count = 0
+
+    @cached_class
+    class ExceptionClass:
+        def __init__(self, value):
+            nonlocal init_count
+            init_count += 1
+            if init_count == 1:
+                raise ValueError("First init failed")
+            self.value = value
+
+    with pytest.raises(ValueError):
+        ExceptionClass(1)
+
+    assert init_count == 1
+
+    # Second attempt should work and use cache
+    inst1 = ExceptionClass(1)
+    inst2 = ExceptionClass(1)
+    assert inst1 is inst2
+    assert init_count == 2
+
+
+def test_property_and_method_behavior():
+    @cached_class
+    class PropertyClass:
+        def __init__(self, value):
+            self._value = value
+
+        @property
+        def value(self):
+            return self._value
+
+        def get_value(self):
+            return self._value
+
+    inst1 = PropertyClass(1)
+    inst2 = PropertyClass(1)
+
+    assert inst1 is inst2
+    assert inst1.value == 1
+    assert inst1.get_value() == 1
+
+
+def test_class_method_and_static_method():
+    @cached_class
+    class MethodClass:
+        def __init__(self, value):
+            self.value = value
+
+        @classmethod
+        def create(cls, value):
+            return cls(value)
+
+        @staticmethod
+        def static_method(value):
+            return value * 2
+
+    inst1 = MethodClass(1)
+    inst2 = MethodClass.create(1)
+    assert inst1 is inst2
+
+    assert MethodClass.static_method(5) == 10
+
+
+def test_nested_cached_classes():
+    @cached_class
+    class OuterClass:
+        def __init__(self, value):
+            self.value = value
+
+        @cached_class
+        class InnerClass:
+            def __init__(self, inner_value):
+                self.inner_value = inner_value
+
+    outer1 = OuterClass(1)
+    outer2 = OuterClass(1)
+    assert outer1 is outer2
+
+    inner1 = outer1.InnerClass(2)
+    inner2 = outer2.InnerClass(2)
+    assert inner1 is inner2
+
+
+def test_large_number_of_instances():
+    @cached_class
+    class LargeNumberClass:
+        def __init__(self, value):
+            self.value = value
+
+    instances = [LargeNumberClass(i) for i in range(1000)]
+    for i, inst in enumerate(instances):
+        assert inst is LargeNumberClass(i)


### PR DESCRIPTION
addresses the issue raised by @comprhys in https://github.com/materialsproject/pymatgen/issues/3898

also adds more comprehensive test coverage