### PR TITLE
Add `Path` to supported type hints for `zpath`

### DIFF
--- a/monty/os/path.py
+++ b/monty/os/path.py
@@ -11,8 +11,8 @@ from monty.fnmatch import WildCard
 from monty.string import list_strings
 
 if TYPE_CHECKING:
-    from typing import Callable, Literal, Optional, Union
     from pathlib import Path
+    from typing import Callable, Literal, Optional, Union
 
 
 def zpath(filename: Union[str, Path]) -> str:

--- a/monty/os/path.py
+++ b/monty/os/path.py
@@ -12,9 +12,10 @@ from monty.string import list_strings
 
 if TYPE_CHECKING:
     from typing import Callable, Literal, Optional, Union
+    from pathlib import Path
 
 
-def zpath(filename: str) -> str:
+def zpath(filename: Union[str, Path]) -> str:
     """
     Returns an existing (zipped or unzipped) file path given the unzipped
     version. If no path exists, returns the filename unmodified.


### PR DESCRIPTION
The `monty.os.zpath` function supports `Path`, so I have included this in the type hint (so downstream libraries using `mypy` don't complain).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the `zpath` function to accept both `str` and `Path` types, improving flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->