### PR TITLE
add pint Quantity support to JSON

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ ci = [
     "tqdm",
     "pymongo",
     "pandas",
+    "pint",
     "orjson",
     "types-orjson",
     "types-requests",


### PR DESCRIPTION
## Summary

Adds support for [pint Quantity](https://pint.readthedocs.io/en/latest/getting/overview.html) objects to `MontyEncoder` / `MontyDecoder`

`pint` is used in MPContribs, pyEQL, and potentially other packages that integrate with the MP ecosystem and is one of the leading python libraries for units handling. Hence, it would be very helpful to have it supported in `monty`.

Serialization is handled by simply converting the object to a `str` as recommended in the [docs](https://pint.readthedocs.io/en/latest/advanced/serialization.html).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for handling `pint.Quantity` objects during serialization and deserialization processes.

- **Tests**
	- Introduced new tests for `pint.Quantity` objects to ensure correct serialization and deserialization.

- **Chores**
	- Updated dependencies to include the `pint` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->