### PR TITLE
Add missing `functools.wraps` decorator to `deprecated` decorator and handle `dataclass` properly

### DIFF
--- a/src/monty/dev.py
+++ b/src/monty/dev.py
@@ -132,8 +132,8 @@ def deprecated(
 
     def deprecated_class_decorator(cls: Type) -> Type:
         # Modify __post_init__ for dataclass
-        if is_dataclass(cls):
-            original_init = cls.__post_init__  # type: ignore[attr-defined]
+        if is_dataclass(cls) and hasattr(cls, "__post_init__"):
+            original_init = cls.__post_init__
         else:
             original_init = cls.__init__
 
@@ -143,8 +143,8 @@ def deprecated(
             warnings.warn(msg, category=category, stacklevel=2)
             original_init(self, *args, **kwargs)
 
-        if is_dataclass(cls):
-            cls.__post_init__ = new_init  # type: ignore[attr-defined]
+        if is_dataclass(cls) and hasattr(cls, "__post_init__"):
+            cls.__post_init__ = new_init
         else:
             cls.__init__ = new_init
 

--- a/src/monty/dev.py
+++ b/src/monty/dev.py
@@ -121,6 +121,7 @@ def deprecated(
         return msg
 
     def deprecated_function_decorator(old: Callable) -> Callable:
+        @functools.wraps(old)
         def wrapped(*args, **kwargs):
             msg = craft_message(old, replacement, message, _deadline)
             warnings.warn(msg, category=category, stacklevel=2)
@@ -131,6 +132,7 @@ def deprecated(
     def deprecated_class_decorator(cls: Type) -> Type:
         original_init = cls.__init__
 
+        @functools.wraps(original_init)
         def new_init(self, *args, **kwargs):
             msg = craft_message(cls, replacement, message, _deadline)
             warnings.warn(msg, category=category, stacklevel=2)

--- a/src/monty/dev.py
+++ b/src/monty/dev.py
@@ -132,8 +132,8 @@ def deprecated(
 
     def deprecated_class_decorator(cls: Type) -> Type:
         # Modify __post_init__ for dataclass
-        if is_dataclass(cls) and hasattr(cls, "__post_init__"):
-            original_init = cls.__post_init__
+        if is_dataclass(cls):
+            original_init = cls.__post_init__  # type: ignore[attr-defined]
         else:
             original_init = cls.__init__
 
@@ -143,8 +143,8 @@ def deprecated(
             warnings.warn(msg, category=category, stacklevel=2)
             original_init(self, *args, **kwargs)
 
-        if is_dataclass(cls) and hasattr(cls, "__post_init__"):
-            cls.__post_init__ = new_init
+        if is_dataclass(cls):
+            cls.__post_init__ = new_init  # type: ignore[attr-defined]
         else:
             cls.__init__ = new_init
 

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -43,22 +43,19 @@ except ImportError:
 try:
     from ruamel.yaml import YAML
 except ImportError:
-    YAML = None  # type: ignore
+    YAML = None
 
 try:
     import orjson
 except ImportError:
-    orjson = None  # type: ignore
+    orjson = None
 
-try:
-    import dataclasses
-except ImportError:
-    dataclasses = None  # type: ignore
+import dataclasses
 
 try:
     import torch
 except ImportError:
-    torch = None  # type: ignore
+    torch = None
 
 __version__ = "3.0.0"
 

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -4,6 +4,7 @@ JSON serialization and deserialization utilities.
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
 import json
 import os
@@ -50,7 +51,6 @@ try:
 except ImportError:
     orjson = None
 
-import dataclasses
 
 try:
     import torch

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -17,10 +17,8 @@ from hashlib import sha1
 from importlib import import_module
 from inspect import getfullargspec
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 from uuid import UUID, uuid4
-
-from _typeshed import DataclassInstance
 
 try:
     import numpy as np
@@ -660,8 +658,7 @@ class MontyEncoder(json.JSONEncoder):
                 and dataclasses.is_dataclass(o)
             ):
                 # This handles dataclasses that are not subclasses of MSONAble.
-
-                d = dataclasses.asdict(cast(o, DataclassInstance))
+                d = dataclasses.asdict(o)  # type: ignore[call-overload]
             elif hasattr(o, "as_dict"):
                 d = o.as_dict()
             elif isinstance(o, Enum):

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -23,22 +23,22 @@ from uuid import UUID, uuid4
 try:
     import numpy as np
 except ImportError:
-    np = None  # type: ignore
+    np = None
 
 try:
     import pydantic
 except ImportError:
-    pydantic = None  # type: ignore
+    pydantic = None
 
 try:
     from pydantic_core import core_schema
 except ImportError:
-    core_schema = None  # type: ignore
+    core_schema = None
 
 try:
     import bson
 except ImportError:
-    bson = None  # type: ignore
+    bson = None
 
 try:
     from ruamel.yaml import YAML

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -6,6 +6,7 @@ import warnings
 from unittest.mock import patch
 
 import pytest
+
 from monty.dev import deprecated, install_excepthook, requires
 
 # Set all warnings to always be triggered.
@@ -129,11 +130,11 @@ class TestDecorator:
             old_class = TestClassOld()
 
         # Check metadata preservation
-        assert TestClassOld.__doc__ == "A dummy old class for tests."
+        assert old_class.__doc__ == "A dummy old class for tests."
         assert old_class.class_attrib_old == "OLD_ATTRIB"
-        assert TestClassOld.__module__ == __name__
+        assert old_class.__module__ == __name__
 
-        assert TestClassOld.method_b.__doc__ == "This is method_b."
+        assert old_class.method_b.__doc__ == "This is method_b."
 
     def test_deprecated_deadline(self, monkeypatch):
         with pytest.raises(DeprecationWarning):

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
-
 from monty.dev import deprecated, install_excepthook, requires
 
 # Set all warnings to always be triggered.

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import datetime
 import unittest
 import warnings
+from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
+
 from monty.dev import deprecated, install_excepthook, requires
 
 # Set all warnings to always be triggered.
@@ -134,6 +136,32 @@ class TestDecorator:
         assert old_class.__module__ == __name__
 
         assert old_class.method_b.__doc__ == "This is method_b."
+
+    def test_deprecated_dataclass(self):
+        @dataclass
+        class TestClassNew:
+            """A dummy class for tests."""
+
+            def method_a(self):
+                pass
+
+        @deprecated(replacement=TestClassNew)
+        @dataclass
+        class TestClassOld:
+            """A dummy old class for tests."""
+
+            class_attrib_old = "OLD_ATTRIB"
+
+            def method_b(self):
+                """This is method_b."""
+                pass
+
+        with pytest.warns(FutureWarning, match="TestClassOld is deprecated"):
+            old_class = TestClassOld()
+
+        # Check metadata preservation
+        assert old_class.__doc__ == "A dummy old class for tests."
+        assert old_class.class_attrib_old == "OLD_ATTRIB"
 
     def test_deprecated_deadline(self, monkeypatch):
         with pytest.raises(DeprecationWarning):

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -6,7 +6,6 @@ import warnings
 from unittest.mock import patch
 
 import pytest
-
 from monty.dev import deprecated, install_excepthook, requires
 
 # Set all warnings to always be triggered.

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
+
 from monty.dev import deprecated, install_excepthook, requires
 
 # Set all warnings to always be triggered.
@@ -141,6 +142,9 @@ class TestDecorator:
         class TestClassNew:
             """A dummy class for tests."""
 
+            def __post_init__(self):
+                print("Hello.")
+
             def method_a(self):
                 pass
 
@@ -150,6 +154,9 @@ class TestDecorator:
             """A dummy old class for tests."""
 
             class_attrib_old = "OLD_ATTRIB"
+
+            def __post_init__(self):
+                print("Hello.")
 
             def method_b(self):
                 """This is method_b."""

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -54,7 +54,7 @@ class TestDecorator:
             def property_a(self):
                 pass
 
-            @property  # type: ignore
+            @property
             @deprecated(property_a)
             def property_b(self):
                 return "b"
@@ -237,9 +237,9 @@ class TestDecorator:
 
     def test_requires(self):
         try:
-            import fictitious_mod  # type: ignore
+            import fictitious_mod
         except ImportError:
-            fictitious_mod = None  # type: ignore
+            fictitious_mod = None
 
         err_msg = "fictitious_mod is not present."
 


### PR DESCRIPTION
### Summary

- Add missing `functools.wraps` decorator to `deprecated` decorator to ensure metadata is passed correctly
- Handle `dataclass` properly, as suggested in https://github.com/materialsproject/atomate2/pull/854#issuecomment-2240262970
- Fix randomly appeared `mypy` errors in `json` module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved handling of deprecated functions and classes for better clarity and usability of warnings, especially for dataclasses.
	- Enhanced type annotation specificity in the JSON handling component, leading to clearer code.

- **Bug Fixes**
	- Ensured proper metadata preservation for deprecated functions and classes to aid in debugging and documentation clarity.

- **Documentation**
	- Updated docstrings to follow Google-style formatting for improved readability and structure.
	- Clarified purposes of deprecated functions and classes through enhanced documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->