### PR TITLE
Lazily import `torch/pydantic` in `json` module, speedup `from monty.json import` by 10x

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 20
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
-        python-version: ["3.9", "3.x"]
+        python-version: ["3.9", "3.12"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-        stages: [commit, commit-msg]
+        stages: [pre-commit, commit-msg]
         exclude_types: [html]
         additional_dependencies: [tomli] # needed to read pyproject.toml below py3.11
 

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
 
+from ruamel.yaml import YAML
+
 try:
     import bson
 except ImportError:
@@ -37,8 +39,6 @@ __version__ = "3.0.0"
 
 def _load_redirect(redirect_file):
     try:
-        from ruamel.yaml import YAML
-
         with open(redirect_file) as f:
             yaml = YAML()
             d = yaml.load(f)

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -796,7 +796,7 @@ class MontyDecoder(json.JSONDecoder):
 
                 elif modname == "torch" and classname == "Tensor":
                     try:
-                        import torch
+                        import torch  # import torch is very expensive
 
                         if "Complex" in d["dtype"]:
                             return torch.tensor(

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -778,7 +778,7 @@ class MontyDecoder(json.JSONDecoder):
                         try:
                             import pydantic
 
-                            if issubclass(cls_, pydantic.BaseModel):  # pylint: disable=E1101
+                            if issubclass(cls_, pydantic.BaseModel):
                                 d = {
                                     k: self.process_decoded(v) for k, v in data.items()
                                 }
@@ -800,13 +800,13 @@ class MontyDecoder(json.JSONDecoder):
                         import torch
 
                         if "Complex" in d["dtype"]:
-                            return torch.tensor(  # pylint: disable=E1101
+                            return torch.tensor(
                                 [
                                     np.array(r) + np.array(i) * 1j
                                     for r, i in zip(*d["data"])
                                 ],
                             ).type(d["dtype"])
-                        return torch.tensor(d["data"]).type(d["dtype"])  # pylint: disable=E1101
+                        return torch.tensor(d["data"]).type(d["dtype"])
 
                     except ImportError:
                         pass
@@ -871,8 +871,8 @@ class MontyDecoder(json.JSONDecoder):
         """
         if orjson is not None:
             try:
-                d = orjson.loads(s)  # pylint: disable=E1101
-            except orjson.JSONDecodeError:  # pylint: disable=E1101
+                d = orjson.loads(s)
+            except orjson.JSONDecodeError:
                 d = json.loads(s)
         else:
             d = json.loads(s)

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -27,11 +27,6 @@ except ImportError:
     bson = None
 
 try:
-    from ruamel.yaml import YAML
-except ImportError:
-    YAML = None
-
-try:
     import orjson
 except ImportError:
     orjson = None
@@ -42,6 +37,8 @@ __version__ = "3.0.0"
 
 def _load_redirect(redirect_file):
     try:
+        from ruamel.yaml import YAML
+
         with open(redirect_file) as f:
             yaml = YAML()
             d = yaml.load(f)

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -41,7 +41,7 @@ except ImportError:
 __version__ = "3.0.0"
 
 
-def _load_redirect(redirect_file):
+def _load_redirect(redirect_file) -> dict:
     try:
         with open(redirect_file) as f:
             yaml = YAML()
@@ -52,7 +52,7 @@ def _load_redirect(redirect_file):
         return {}
 
     # Convert the full paths to module/class
-    redirect_dict = defaultdict(dict)
+    redirect_dict: dict = defaultdict(dict)
     for old_path, new_path in d.items():
         old_class = old_path.split(".")[-1]
         old_module = ".".join(old_path.split(".")[:-1])

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -586,8 +586,8 @@ class MontyEncoder(json.JSONEncoder):
         if isinstance(o, Path):
             return {"@module": "pathlib", "@class": "Path", "string": str(o)}
 
-        if torch is not None and isinstance(o, torch.Tensor):
-            # Support for Pytorch Tensors.
+        # Support for Pytorch Tensors
+        if _check_type(o, "torch.Tensor"):
             d: dict[str, Any] = {
                 "@module": "torch",
                 "@class": "Tensor",

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -52,11 +52,6 @@ except ImportError:
     orjson = None
 
 
-try:
-    import torch
-except ImportError:
-    torch = None
-
 __version__ = "3.0.0"
 
 
@@ -803,15 +798,21 @@ class MontyDecoder(json.JSONDecoder):
                             d = {k: self.process_decoded(v) for k, v in data.items()}
                             return cls_(**d)
 
-                elif torch is not None and modname == "torch" and classname == "Tensor":
-                    if "Complex" in d["dtype"]:
-                        return torch.tensor(  # pylint: disable=E1101
-                            [
-                                np.array(r) + np.array(i) * 1j
-                                for r, i in zip(*d["data"])
-                            ],
-                        ).type(d["dtype"])
-                    return torch.tensor(d["data"]).type(d["dtype"])  # pylint: disable=E1101
+                elif modname == "torch" and classname == "Tensor":
+                    try:
+                        import torch
+
+                        if "Complex" in d["dtype"]:
+                            return torch.tensor(  # pylint: disable=E1101
+                                [
+                                    np.array(r) + np.array(i) * 1j
+                                    for r, i in zip(*d["data"])
+                                ],
+                            ).type(d["dtype"])
+                        return torch.tensor(d["data"]).type(d["dtype"])  # pylint: disable=E1101
+
+                    except ImportError:
+                        pass
 
                 elif np is not None and modname == "numpy" and classname == "array":
                     if d["dtype"].startswith("complex"):

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -64,7 +64,7 @@ def _load_redirect(redirect_file):
     return dict(redirect_dict)
 
 
-def _check_type(obj, type_str) -> bool:
+def _check_type(obj, type_str: tuple[str, ...] | str) -> bool:
     """Alternative to isinstance that avoids imports.
 
     Checks whether obj is an instance of the type defined by type_str. This

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -98,7 +98,7 @@ def _check_type(obj, type_str) -> bool:
         mro = type(obj).mro()
     except TypeError:
         return False
-    return any(o.__module__ + "." + o.__name__ == ts for o in mro for ts in type_str)
+    return any(f"{o.__module__}.{o.__name__}" == ts for o in mro for ts in type_str)
 
 
 class MSONable:


### PR DESCRIPTION
### Summary

- Lazily import `torch/pydantic` for `monty.json`, thanks for @janosh's profiling in https://github.com/janosh/pymatviz/issues/209#issuecomment-2423174822, would significantly speed up `from monty.json import MSONable/MontyEncoder/MontyDecoder/...`

---

## Performance comparison

- Following benchmark done with **optional dependencies installed** (otherwise import would be skipped), averaged across 10 runs
- Python 3.12.7, MacOS 15.0.1 with M3 chip
- Profile with: `python -X importtime -c  "from monty.json import MSONable" 2> monty.log && tuna monty.log`

<details>
<summary> Benchmark Script (by GPT) </summary>

```python
import time
import subprocess


def measure_import_time(command: str, repeats: int):
    total_time = 0

    for _ in range(repeats):
        start_time = time.time()

        # Run the Python command in a new process
        subprocess.run(["python", "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)

        end_time = time.time()
        total_time += (end_time - start_time)

    avg_time_ms = (total_time / repeats) * 1000
    print(f"Average import time for '{command}': {avg_time_ms:.3f} ms")

def main():
    commands = [
        "from monty.json import MSONable",
        "from monty.json import MontyEncoder",
        "from monty.json import MontyDecoder",
    ]

    for command in commands:
        measure_import_time(command, repeats=10)

if __name__ == "__main__":
    main()

```

</details>


### Import time from master branch
```
Average import time for 'from monty.json import MSONable': 924.585 ms
Average import time for 'from monty.json import MontyEncoder': 735.797 ms
Average import time for 'from monty.json import MontyDecoder': 720.402 ms
```

Import time traced for `from monty.json import MSONable`:
<img width="1505" alt="image" src="https://github.com/user-attachments/assets/984d1cb3-7060-46bb-a694-0fb07c04dbc0">

### Import time from tip of this PR
```
Average import time for 'from monty.json import MSONable': 109.053 ms
Average import time for 'from monty.json import MontyEncoder': 111.683 ms
Average import time for 'from monty.json import MontyDecoder': 103.302 ms
```

<img width="1356" alt="image" src="https://github.com/user-attachments/assets/1c8e7ee0-6d0e-4311-be67-fc8207f3ddc3">

---

### After lazily import `torch`

```
Average import time for 'from monty.json import MSONable': 122.606 ms
Average import time for 'from monty.json import MontyEncoder': 123.456 ms
Average import time for 'from monty.json import MontyDecoder': 117.621 ms
```

<img width="1505" alt="image" src="https://github.com/user-attachments/assets/59bd3af4-1a99-4b73-9ca1-c93b3a62d4b1">

---

### After lazily import `numpy` as well (reverted, as use of np is very common)

```
Average import time for 'from monty.json import MSONable': 58.586 ms
Average import time for 'from monty.json import MontyEncoder': 59.323 ms
Average import time for 'from monty.json import MontyDecoder': 58.300 ms
```

<img width="1505" alt="image" src="https://github.com/user-attachments/assets/b1de8b21-cc9e-4d48-8c31-a518575a96e3">

---

### After lazily import `pydantic` too (limited improvement from here)

```
Average import time for 'from monty.json import MSONable': 54.003 ms
Average import time for 'from monty.json import MontyEncoder': 53.038 ms
Average import time for 'from monty.json import MontyDecoder': 52.875 ms
```

<img width="1505" alt="image" src="https://github.com/user-attachments/assets/6566c8f3-f038-4676-b296-3f7c6cc9f8ab">

---

### After lazily import `ruamel.yaml` (reverted, no obvious improvement)

```
Average import time for 'from monty.json import MSONable': 52.769 ms
Average import time for 'from monty.json import MontyEncoder': 52.191 ms
Average import time for 'from monty.json import MontyDecoder': 60.379 ms
```

<img width="1505" alt="image" src="https://github.com/user-attachments/assets/35c347b9-afbc-4fe4-939a-64a607b38538">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety and error handling in JSON processing.
- **Chores**
	- Updated GitHub Actions workflow for linting to use the latest Python setup action.
	- Modified pre-commit hook configuration to run codespell during the pre-commit phase.
	- Updated testing workflow to include Python 3.12 in the testing environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->