### PR TITLE
Declare required and optional dependency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,9 +19,12 @@ jobs:
 
       - name: ruff
         run: |
+          ruff --version
           ruff check .
           ruff format --check .
 
       - name: mypy
         run: |
+          mypy --version
+          rm -rf .mypy_cache
           mypy src

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,12 +19,9 @@ jobs:
 
       - name: ruff
         run: |
-          ruff --version
           ruff check .
           ruff format --check .
 
       - name: mypy
         run: |
-          mypy --version
-          rm -rf .mypy_cache
           mypy src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on: [push, pull_request, workflow_call]
 jobs:
   build:
     strategy:
+      fail-fast: false
       max-parallel: 20
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ ci = [
   "types-orjson",
   "types-requests",
 ]
+# dev is for "dev" module, not for development
 dev = ["ipython"]
 docs = [
     "sphinx",
@@ -49,6 +50,7 @@ json = [
 multiprocessing = ["tqdm"]
 optional = ["monty[dev,json,multiprocessing,serialization]"]
 serialization = ["msgpack"]
+task = ["requests", "invoke"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ ci = [
   "monty[optional]",
   "pytest>=8",
   "pytest-cov>=4",
-  "types-orjson",
   "types-requests",
 ]
 # dev is for "dev" module, not for development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ ci = [
     "pytest>=8",
     "pytest-cov>=4",
     "coverage",
-    "pymongo",  # TODO: not used?
     "types-orjson",
     "types-requests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ docs = [
 ]
 json = [
   "bson",
-  "orjson",
+  "orjson>=3.6.1",
   "pandas",
   "pydantic",
   "pint",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,26 +19,38 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-
+  "ruamel.yaml",
+  "numpy<2.0.0",
 ]
 version = "2024.7.30"
 
 [project.optional-dependencies]
+json = [
+  "pydantic",
+  "orjson",
+  "bson",
+  "pandas",
+  "torch",
+  "pint",
+]
+serialization = [
+  "msgpack",
+ ]
+multiprocessing = [
+  "tqdm",
+]
+dev = [
+  "ipython",
+]
+
 ci = [
+    "monty[json,serialization,multiprocessing,dev]",
     "pytest>=8",
     "pytest-cov>=4",
     "coverage",
-    "numpy<2.0.0",
-    "ruamel.yaml",
-    "msgpack",
-    "tqdm",
-    "pymongo",
-    "pandas",
-    "pint",
-    "orjson",
+    "pymongo",  # TODO: not used?
     "types-orjson",
     "types-requests",
-    "torch"
 ]
 docs = [
     "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ docs = [
     "sphinx",
     "sphinx_rtd_theme",
 ]
-io = ["lzma"]
 json = [
   "bson",
   "orjson",
@@ -48,7 +47,7 @@ json = [
   "torch",
 ]
 multiprocessing = ["tqdm"]
-optional = ["monty[dev,io,json,multiprocessing,serialization]"]
+optional = ["monty[dev,json,multiprocessing,serialization]"]
 serialization = ["msgpack"]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,36 +25,30 @@ dependencies = [
 version = "2024.7.30"
 
 [project.optional-dependencies]
-json = [
-  "pydantic",
-  "orjson",
-  "bson",
-  "pandas",
-  "torch",
-  "pint",
-]
-serialization = [
-  "msgpack",
- ]
-multiprocessing = [
-  "tqdm",
-]
-dev = [
-  "ipython",
-]
-
 ci = [
-    "monty[json,serialization,multiprocessing,dev]",
-    "pytest>=8",
-    "pytest-cov>=4",
-    "coverage",
-    "types-orjson",
-    "types-requests",
+  "coverage",
+  "monty[optional]",
+  "pytest>=8",
+  "pytest-cov>=4",
+  "types-orjson",
+  "types-requests",
 ]
+dev = ["ipython"]
 docs = [
     "sphinx",
     "sphinx_rtd_theme",
 ]
+json = [
+  "bson",
+  "orjson",
+  "pandas",
+  "pydantic",
+  "pint",
+  "torch",
+]
+multiprocessing = ["tqdm"]
+optional = ["monty[dev,json,multiprocessing,serialization]"]
+serialization = ["msgpack"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,4 @@ lint.select = [
 ]
 
 lint.isort.required-imports = ["from __future__ import annotations"]
+lint.isort.known-first-party = ["monty"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ docs = [
     "sphinx",
     "sphinx_rtd_theme",
 ]
+io = ["lzma"]
 json = [
   "bson",
   "orjson",
@@ -47,7 +48,7 @@ json = [
   "torch",
 ]
 multiprocessing = ["tqdm"]
-optional = ["monty[dev,json,multiprocessing,serialization]"]
+optional = ["monty[dev,io,json,multiprocessing,serialization]"]
 serialization = ["msgpack"]
 
 [tool.setuptools.packages.find]

--- a/src/monty/dev.py
+++ b/src/monty/dev.py
@@ -231,9 +231,8 @@ def install_excepthook(hook_type: str = "color", **kwargs) -> int:
     """
     try:
         from IPython.core import ultratb  # pylint: disable=import-outside-toplevel
-    except ImportError:
-        warnings.warn("Cannot install excepthook, IPython not installed")
-        return 1
+    except ImportError as exc:
+        raise ImportError("Cannot install excepthook, IPython not installed") from exc
 
     # Select the hook.
     hook = dict(

--- a/src/monty/dev.py
+++ b/src/monty/dev.py
@@ -232,7 +232,7 @@ def install_excepthook(hook_type: str = "color", **kwargs) -> int:
     try:
         from IPython.core import ultratb  # pylint: disable=import-outside-toplevel
     except ImportError:
-        warnings.warn("Cannot install excepthook, IPyhon.core.ultratb not available")
+        warnings.warn("Cannot install excepthook, IPython not installed")
         return 1
 
     # Select the hook.

--- a/src/monty/io.py
+++ b/src/monty/io.py
@@ -9,11 +9,7 @@ import bz2
 import errno
 import gzip
 import io
-
-try:
-    import lzma
-except ImportError:
-    lzma = None  # type: ignore[assignment]
+import lzma
 import mmap
 import os
 import subprocess

--- a/src/monty/io.py
+++ b/src/monty/io.py
@@ -45,7 +45,7 @@ def zopen(filename: Union[str, Path], *args, **kwargs) -> IO:
         return bz2.open(filename, *args, **kwargs)
     if ext in {".GZ", ".Z"}:
         return gzip.open(filename, *args, **kwargs)
-    if lzma is not None and ext in {".XZ", ".LZMA"}:
+    if ext in {".XZ", ".LZMA"}:
         return lzma.open(filename, *args, **kwargs)
     return open(filename, *args, **kwargs)
 

--- a/src/monty/itertools.py
+++ b/src/monty/itertools.py
@@ -7,10 +7,7 @@ from __future__ import annotations
 import itertools
 from typing import TYPE_CHECKING
 
-try:
-    import numpy as np
-except ImportError:
-    np = None
+import numpy as np
 
 if TYPE_CHECKING:
     from typing import Iterable

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
 
+from ruamel.yaml import YAML
+
 try:
     import numpy as np
 except ImportError:
@@ -42,15 +44,9 @@ except ImportError:
     bson = None
 
 try:
-    from ruamel.yaml import YAML
-except ImportError:
-    YAML = None
-
-try:
     import orjson
 except ImportError:
     orjson = None
-
 
 try:
     import torch

--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -659,7 +659,7 @@ class MontyEncoder(json.JSONEncoder):
                 and dataclasses.is_dataclass(o)
             ):
                 # This handles dataclasses that are not subclasses of MSONAble.
-                d = dataclasses.asdict(o)  # type: ignore[call-overload]
+                d = dataclasses.asdict(o)  # type: ignore[call-overload, arg-type]
             elif hasattr(o, "as_dict"):
                 d = o.as_dict()
             elif isinstance(o, Enum):

--- a/src/monty/multiprocessing.py
+++ b/src/monty/multiprocessing.py
@@ -9,8 +9,8 @@ from typing import Callable, Iterable
 
 try:
     from tqdm.autonotebook import tqdm
-except ImportError:
-    tqdm = None
+except ImportError as exc:
+    raise ImportError("tqdm must be installed for this function.") from exc
 
 
 def imap_tqdm(nprocs: int, func: Callable, iterable: Iterable, *args, **kwargs) -> list:
@@ -28,8 +28,6 @@ def imap_tqdm(nprocs: int, func: Callable, iterable: Iterable, *args, **kwargs) 
     Returns:
         Results of Pool.imap.
     """
-    if tqdm is None:
-        raise ImportError("tqdm must be installed for this function.")
     data = []
     with Pool(nprocs) as pool:
         try:

--- a/src/monty/serialization.py
+++ b/src/monty/serialization.py
@@ -9,10 +9,7 @@ import json
 import os
 from typing import TYPE_CHECKING
 
-try:
-    from ruamel.yaml import YAML
-except ImportError:
-    YAML = None  # type: ignore[arg-type]
+from ruamel.yaml import YAML
 
 from monty.io import zopen
 from monty.json import MontyDecoder, MontyEncoder

--- a/tasks.py
+++ b/tasks.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import requests
 from invoke import task
+
 from monty import __version__ as ver
 from monty.os import cd
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 
 import pytest
+
 from monty.collections import AttrDict, FrozenAttrDict, Namespace, frozendict, tree
 
 TEST_DIR = os.path.join(os.path.dirname(__file__), "test_files")

--- a/tests/test_design_patterns.py
+++ b/tests/test_design_patterns.py
@@ -6,6 +6,7 @@ import weakref
 from typing import Any
 
 import pytest
+
 from monty.design_patterns import cached_class, singleton
 
 

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
+
 from monty.dev import deprecated, install_excepthook, requires
 
 # Set all warnings to always be triggered.

--- a/tests/test_fractions.py
+++ b/tests/test_fractions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from monty.fractions import gcd, gcd_float, lcm
 
 

--- a/tests/test_functools.py
+++ b/tests/test_functools.py
@@ -5,6 +5,7 @@ import time
 import unittest
 
 import pytest
+
 from monty.functools import (
     TimeoutError,
     lazy_property,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
 from monty.io import (
     FileLock,
     FileLockException,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -9,6 +9,17 @@ from enum import Enum
 from typing import Union
 
 import numpy as np
+import pytest
+from monty.json import (
+    MontyDecoder,
+    MontyEncoder,
+    MSONable,
+    _load_redirect,
+    jsanitize,
+    load,
+)
+
+from . import __version__ as TESTS_VERSION
 
 try:
     import pandas as pd
@@ -34,18 +45,6 @@ try:
     from bson.objectid import ObjectId
 except ImportError:
     ObjectId = None
-
-import pytest
-from monty.json import (
-    MontyDecoder,
-    MontyEncoder,
-    MSONable,
-    _load_redirect,
-    jsanitize,
-    load,
-)
-
-from . import __version__ as tests_version
 
 TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_files")
 
@@ -317,7 +316,7 @@ class TestMSONable:
     def test_version(self):
         obj = self.good_cls("Hello", "World", "Python")
         d = obj.as_dict()
-        assert d["@version"] == tests_version
+        assert d["@version"] == TESTS_VERSION
 
     def test_nested_to_from_dict(self):
         GMC = GoodMSONClass

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -10,6 +10,7 @@ from typing import Union
 
 import numpy as np
 import pytest
+
 from monty.json import (
     MontyDecoder,
     MontyEncoder,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -8,10 +8,7 @@ import pathlib
 from enum import Enum
 from typing import Union
 
-try:
-    import numpy as np
-except ImportError:
-    np = None
+import numpy as np
 
 try:
     import pandas as pd
@@ -564,7 +561,6 @@ class TestJson:
         d = json.loads(djson)
         assert isinstance(d[0], float)
 
-    @pytest.mark.skipif(np is None, reason="numpy not present")
     def test_numpy(self):
         x = np.array([1, 2, 3], dtype="int64")
         with pytest.raises(TypeError):
@@ -872,9 +868,7 @@ class TestJson:
         clean = jsanitize(s)
         assert clean == s.to_dict()
 
-    @pytest.mark.skipif(
-        np is None or ObjectId is None, reason="numpy and bson not present"
-    )
+    @pytest.mark.skipif(ObjectId is None, reason="bson not present")
     def test_jsanitize_numpy_bson(self):
         d = {
             "a": ["b", np.array([1, 2, 3])],

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 
 import pytest
+
 from monty.os import cd, makedirs_p
 from monty.os.path import find_exts, zpath
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import pytest
+
 from monty.serialization import dumpfn, loadfn
 from monty.tempfile import ScratchDir
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -6,14 +6,13 @@ import os
 import unittest
 
 import pytest
+from monty.serialization import dumpfn, loadfn
+from monty.tempfile import ScratchDir
 
 try:
     import msgpack
 except ImportError:
     msgpack = None
-
-from monty.serialization import dumpfn, loadfn
-from monty.tempfile import ScratchDir
 
 
 class TestSerial:

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -9,6 +9,7 @@ from gzip import GzipFile
 from pathlib import Path
 
 import pytest
+
 from monty.shutil import (
     compress_dir,
     compress_file,

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -4,6 +4,7 @@ import os
 import shutil
 
 import pytest
+
 from monty.tempfile import ScratchDir
 
 TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_files")


### PR DESCRIPTION
### Summary

- Add `rualmel.yaml` and `numpy` to required dependencies (as they are used by more than one module), and remove import guard for `ruamel.yaml` and `numpy`
- Declare the rest as optional dependencies, group by module, should make it easier for users to install
- `lzma` is [built in after python 3.3](https://docs.python.org/3/library/lzma.html)


It would then be much easier to install extra dependencies (`pip install monty[json]` or `pip install monty[optional]` to install all extras) without need to dig into the code to find out what is required

