### PR TITLE
release numpy <2 pin, and support python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,18 +8,18 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
-        python-version: ["3.9", "3.13"]
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 20
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.13"]
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ json = [
   "orjson>=3.6.1",
   "pandas",
   "pydantic",
-  "pint",
+  # https://github.com/hgrecco/pint/issues/2065
+  "pint; python_version<'3.13'",
   # Note: need torch>=2.3.0 for numpy 2 # 719
   "torch; python_version<'3.13'",  # python 3.13 not supported yet
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ maintainers = [
 ]
 description = "Monty is the missing complement to Python."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.9,<=3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
   "ruamel.yaml",
-  "numpy",
+  "numpy>=2",
 ]
 version = "2024.10.21"
 
@@ -44,7 +44,7 @@ json = [
   "pandas",
   "pydantic",
   "pint",
-  "torch",  # need torch>=2.3.0 for numpy 2
+  "torch==2.2.2",  # need torch>=2.3.0 for numpy 2
 ]
 multiprocessing = ["tqdm"]
 optional = ["monty[dev,json,multiprocessing,serialization]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ json = [
   "pandas",
   "pydantic",
   "pint",
-  "torch>=2.3.0",  # need torch>=2.3.0 for numpy 2 # 719
+  "torch",  # Note: need torch>=2.3.0 for numpy 2 # 719
 ]
 multiprocessing = ["tqdm"]
 optional = ["monty[dev,json,multiprocessing,serialization]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
   "ruamel.yaml",
-  "numpy>=2",
+  "numpy",
 ]
 version = "2024.10.21"
 
@@ -44,7 +44,7 @@ json = [
   "pandas",
   "pydantic",
   "pint",
-  "torch==2.2.2",  # need torch>=2.3.0 for numpy 2
+  "torch>=2.3.0",  # need torch>=2.3.0 for numpy 2 # 719
 ]
 multiprocessing = ["tqdm"]
 optional = ["monty[dev,json,multiprocessing,serialization]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ json = [
   "pandas",
   "pydantic",
   "pint",
-  "torch",  # Note: need torch>=2.3.0 for numpy 2 # 719
+  # Note: need torch>=2.3.0 for numpy 2 # 719
+  "torch; python_version<'3.13'",  # python 3.13 not supported yet
 ]
 multiprocessing = ["tqdm"]
 optional = ["monty[dev,json,multiprocessing,serialization]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
   "ruamel.yaml",
-  "numpy<2.0.0",
+  "numpy",
 ]
 version = "2024.10.21"
 
@@ -44,7 +44,7 @@ json = [
   "pandas",
   "pydantic",
   "pint",
-  "torch",
+  "torch",  # need torch>=2.3.0 for numpy 2
 ]
 multiprocessing = ["tqdm"]
 optional = ["monty[dev,json,multiprocessing,serialization]"]


### PR DESCRIPTION
- release numpy <2 pin and support python 3.13, close #717


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated Python version requirements to support up to 3.13.
	- Enhanced dependency management for `numpy`, `pint`, and `torch`.

- **Bug Fixes**
	- Improved compatibility notes for `torch` dependency concerning `numpy 2`.

- **Chores**
	- Adjusted GitHub Actions workflow to reflect updated Python versions for testing, now covering versions 3.9 through 3.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->