### PR TITLE
Fix custom dict overriding in `collections`

### DIFF
--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -101,7 +101,7 @@ class ControlledDict(collections.UserDict, ABC):
 
         super().update(*args, **kwargs)
 
-    def setdefault(self, key, default=None) -> None:
+    def setdefault(self, key, default=None) -> Any:
         """Forbid adding or updating keys based on _allow_add and _allow_update.
 
         Note: if not _allow_update, this method would NOT check whether the

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -31,7 +31,7 @@ def tree() -> collections.defaultdict:
 class frozendict(dict):
     """
     A dictionary that does not permit changes. The naming
-    violates PEP 8 to be consistent with standard Python's "frozenset" naming.
+    violates PEP 8 to be consistent with the built-in "frozenset" naming.
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -88,7 +88,7 @@ class AttrDict(dict):
 
     Examples:
         >>> dct = AttrDict(foo=1, bar=2)
-        >>> assert dct["foo"] == dct.foo
+        >>> assert dct["foo"] is dct.foo
         >>> dct.bar = "hello"
         >>> assert dct.bar == "hello"
     """

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -79,7 +79,7 @@ class ControlledDict(collections.UserDict, ABC):
 
     # Override add/update operations
     def __setitem__(self, key, value):
-        """Forbid adding or updating keys based on allow_add and allow_update."""
+        """Forbid adding or updating keys based on _allow_add and _allow_update."""
         if key not in self.data and not self._allow_add:
             raise TypeError(f"Cannot add new key {key!r}, because add is disabled.")
         elif key in self.data and not self._allow_update:
@@ -88,7 +88,7 @@ class ControlledDict(collections.UserDict, ABC):
         super().__setitem__(key, value)
 
     def update(self, *args, **kwargs):
-        """Forbid adding or updating keys based on allow_add and allow_update."""
+        """Forbid adding or updating keys based on _allow_add and _allow_update."""
         for key in dict(*args, **kwargs):
             if key not in self.data and not self._allow_add:
                 raise TypeError(
@@ -102,9 +102,9 @@ class ControlledDict(collections.UserDict, ABC):
         super().update(*args, **kwargs)
 
     def setdefault(self, key, default=None):
-        """Forbid adding or updating keys based on allow_add and allow_update.
+        """Forbid adding or updating keys based on _allow_add and _allow_update.
 
-        Note: if not allow_update, this method would NOT check whether the
+        Note: if not _allow_update, this method would NOT check whether the
             new default value is the same as current value for efficiency.
         """
         if key not in self.data:
@@ -121,25 +121,25 @@ class ControlledDict(collections.UserDict, ABC):
 
     # Override delete operations
     def __delitem__(self, key):
-        """Forbid deleting keys when self.allow_del is False."""
+        """Forbid deleting keys when self._allow_del is False."""
         if not self._allow_del:
             raise TypeError(f"Cannot delete key {key!r}, because delete is disabled.")
         super().__delitem__(key)
 
     def pop(self, key, *args):
-        """Forbid popping keys when self.allow_del is False."""
+        """Forbid popping keys when self._allow_del is False."""
         if not self._allow_del:
             raise TypeError(f"Cannot pop key {key!r}, because delete is disabled.")
         return super().pop(key, *args)
 
     def popitem(self):
-        """Forbid popping the last item when self.allow_del is False."""
+        """Forbid popping the last item when self._allow_del is False."""
         if not self._allow_del:
             raise TypeError("Cannot pop item, because delete is disabled.")
         return super().popitem()
 
     def clear(self):
-        """Forbid clearing the dictionary when self.allow_del is False."""
+        """Forbid clearing the dictionary when self._allow_del is False."""
         if not self._allow_del:
             raise TypeError("Cannot clear dictionary, because delete is disabled.")
         super().clear()
@@ -201,7 +201,7 @@ class FrozenAttrDict(frozendict):
     """
     A dictionary that:
         - Does not permit changes (add/update/delete).
-        - Allow accessing values as `dct.key` in addition to
+        - Allows accessing values as `dct.key` in addition to
             the traditional way `dct["key"]`.
     """
 

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -156,7 +156,7 @@ class frozendict(ControlledDict):
     _allow_update: bool = False
 
 
-class Namespace(ControlledDict):  # TODO: this name is a bit confusing, deprecate it?
+class Namespace(ControlledDict):
     """A dictionary that does not permit update/delete its values (but allows add)."""
 
     _allow_add: bool = True

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -56,7 +56,6 @@ class ControlledDict(collections.UserDict, ABC):
             - setter method: `__setitem__`
             - `setdefault`
             - `update`
-            - Merging dictionaries using `|=`
 
         - Deleting items:
             - `del dict[key]`
@@ -84,20 +83,6 @@ class ControlledDict(collections.UserDict, ABC):
             )
 
         super().__setitem__(key, value)
-
-    def __ior__(self, other):
-        """Handle the |= operator for dictionary updates."""
-        for key in other:
-            if key not in self.data and not self.allow_add:
-                raise TypeError(
-                    f"Cannot add new key using |= operator: {key!r}, because allow_add is set to False."
-                )
-            elif key in self.data and not self.allow_update:
-                raise TypeError(
-                    f"Cannot update key using |= operator: {key!r}, because allow_update is set to False."
-                )
-
-        return super().__ior__(other)
 
     def update(self, *args, **kwargs):
         """Forbid adding or updating keys based on allow_add and allow_update."""

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -68,6 +68,18 @@ class ControlledDict(collections.UserDict, ABC):
     allow_del: ClassVar[bool] = True
     allow_update: ClassVar[bool] = True
 
+    def __init__(self, *args, **kwargs):
+        """Temporarily allow all add/update during initialization."""
+        original_allow_add = self.allow_add
+        original_allow_update = self.allow_update
+        try:
+            self.allow_add = True
+            self.allow_update = True
+            super().__init__(*args, **kwargs)
+        finally:
+            self.allow_add = original_allow_add
+            self.allow_update = original_allow_update
+
     # TODO: extract checkers
 
     # Overriding add/update operations
@@ -142,30 +154,15 @@ class ControlledDict(collections.UserDict, ABC):
         super().clear()
 
 
-class frozendict(dict):
+class frozendict(ControlledDict):
     """
     A dictionary that does not permit changes. The naming
-    violates PEP 8 to be consistent with the built-in "frozenset" naming.
+    violates PEP 8 to be consistent with the built-in `frozenset` naming.
     """
 
-    def __init__(self, *args, **kwargs) -> None:
-        """
-        Args:
-            args: Passthrough arguments for standard dict.
-            kwargs: Passthrough keyword arguments for standard dict.
-        """
-        dict.__init__(self, *args, **kwargs)
-
-    def __setitem__(self, key: Any, val: Any) -> None:
-        raise TypeError(f"{type(self).__name__} does not support item assignment")
-
-    def update(self, *args, **kwargs) -> None:
-        """
-        Args:
-            args: Passthrough arguments for standard dict.
-            kwargs: Passthrough keyword arguments for standard dict.
-        """
-        raise TypeError(f"Cannot update a {self.__class__.__name__}")
+    allow_add: ClassVar[bool] = False
+    allow_del: ClassVar[bool] = False
+    allow_update: ClassVar[bool] = False
 
 
 class Namespace(dict):  # TODO: this name is a bit confusing, deprecate it?

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -20,7 +20,7 @@ def tree() -> collections.defaultdict:
 
     Usage:
         x = tree()
-        x['a']['b']['c'] = 1
+        x["a"]["b"]["c"] = 1
 
     Returns:
         A tree.
@@ -31,7 +31,7 @@ def tree() -> collections.defaultdict:
 class frozendict(dict):
     """
     A dictionary that does not permit changes. The naming
-    violates PEP8 to be consistent with standard Python's "frozenset" naming.
+    violates PEP 8 to be consistent with standard Python's "frozenset" naming.
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -55,7 +55,7 @@ class frozendict(dict):
 
 
 class Namespace(dict):
-    """A dictionary that does not permit to redefine its keys."""
+    """A dictionary that does not permit changing its values."""
 
     def __init__(self, *args, **kwargs) -> None:
         """
@@ -67,7 +67,7 @@ class Namespace(dict):
 
     def __setitem__(self, key: Any, val: Any) -> None:
         if key in self:
-            raise KeyError(f"Cannot overwrite existent key: {key!s}")
+            raise KeyError(f"Cannot overwrite existing key: {key!s}")
 
         dict.__setitem__(self, key, val)
 
@@ -83,14 +83,14 @@ class Namespace(dict):
 
 class AttrDict(dict):
     """
-    Allows to access dict keys as obj.foo in addition
-    to the traditional way obj['foo']"
+    Allows to access values as dct.key in addition
+    to the traditional way dct["key"]
 
     Examples:
-        >>> d = AttrDict(foo=1, bar=2)
-        >>> assert d["foo"] == d.foo
-        >>> d.bar = "hello"
-        >>> assert d.bar == "hello"
+        >>> dct = AttrDict(foo=1, bar=2)
+        >>> assert dct["foo"] == dct.foo
+        >>> dct.bar = "hello"
+        >>> assert dct.bar == "hello"
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -114,9 +114,9 @@ class AttrDict(dict):
 class FrozenAttrDict(frozendict):
     """
     A dictionary that:
-        * does not permit changes.
-        * Allows to access dict keys as obj.foo in addition
-          to the traditional way obj['foo']
+        - Does not permit changes.
+        - Allows to access values as dct.key in addition
+          to the traditional way dct["key"]
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -186,7 +186,6 @@ class MongoDict:
         try:
             return super().__getattribute__(name)
         except AttributeError:
-            # raise
             try:
                 a = self._mongo_dict_[name]
                 if isinstance(a, collections.abc.Mapping):
@@ -232,8 +231,8 @@ def dict2namedtuple(*args, **kwargs) -> tuple:
         - Don't use this function in code in which memory and performance are
           crucial since a dict is needed to instantiate the tuple!
     """
-    d = collections.OrderedDict(*args)
-    d.update(**kwargs)
+    dct = collections.OrderedDict(*args)
+    dct.update(**kwargs)
     return collections.namedtuple(
-        typename="dict2namedtuple", field_names=list(d.keys())
-    )(**d)
+        typename="dict2namedtuple", field_names=list(dct.keys())
+    )(**dct)

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -2,6 +2,7 @@
 Useful collection classes:
     - tree: A recursive `defaultdict` for creating nested dictionaries
         with default values.
+    - ControlledDict: A base dict class with configurable mutability.
     - frozendict: An immutable dictionary.
     - Namespace: A dict doesn't allow changing values, but could
         add new keys,
@@ -53,7 +54,7 @@ class ControlledDict(collections.UserDict, ABC):
     allow_update: ClassVar[bool] = True
 
     def __setitem__(self, key, value):
-        """Forbid set when self.ADD is False."""
+        """Forbid set when self.allow_add is False."""
         if key not in self.data and not self.allow_add:
             raise TypeError("Cannot add new key, because add is disabled.")
 
@@ -273,7 +274,7 @@ class MongoDict:
 
 def dict2namedtuple(*args, **kwargs) -> tuple:
     """
-    Helper function to create a class `namedtuple` from a dictionary.
+    Helper function to create a `namedtuple` from a dictionary.
 
     Examples:
         >>> tpl = dict2namedtuple(foo=1, bar="hello")
@@ -284,12 +285,11 @@ def dict2namedtuple(*args, **kwargs) -> tuple:
 
     Warnings:
         - The order of the items in the namedtuple is not deterministic if
-          kwargs are used.
-          namedtuples, however, should always be accessed by attribute hence
-          this behaviour should not represent a serious problem.
+          `kwargs` are used. namedtuples, however, should always be accessed
+          by attribute hence this behaviour should not be a serious problem.
 
-        - Don't use this function in code in which memory and performance are
-          crucial since a dict is needed to instantiate the tuple!
+        - Don't use this function in code where memory and performance are
+          crucial, since a dict is needed to instantiate the tuple!
     """
     dct = collections.OrderedDict(*args)
     dct.update(**kwargs)

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -216,11 +216,11 @@ def dict2namedtuple(*args, **kwargs) -> tuple:
     Helper function to create a class `namedtuple` from a dictionary.
 
     Examples:
-        >>> t = dict2namedtuple(foo=1, bar="hello")
-        >>> assert t.foo == 1 and t.bar == "hello"
+        >>> tpl = dict2namedtuple(foo=1, bar="hello")
+        >>> assert tpl.foo == 1 and tpl.bar == "hello"
 
-        >>> t = dict2namedtuple([("foo", 1), ("bar", "hello")])
-        >>> assert t[0] == t.foo and t[1] == t.bar
+        >>> tpl = dict2namedtuple([("foo", 1), ("bar", "hello")])
+        >>> assert tpl[0] is tpl.foo and t[1] is tpl.bar
 
     Warnings:
         - The order of the items in the namedtuple is not deterministic if

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -1,14 +1,24 @@
 """
-Useful collection classes, e.g., tree, frozendict, etc.
+Useful collection classes:
+    - tree: A recursive `defaultdict` for creating nested dictionaries
+        with default values.
+    - frozendict: An immutable dictionary.
+    - Namespace: A dict doesn't allow changing values, but could
+        add new keys,
+    - AttrDict: A dict whose values could be access as `dct.key`.
+    - FrozenAttrDict: An immutable version of `AttrDict`.
+    - MongoDict: A dict-like object whose values are nested dicts
+        could be accessed as attributes.
 """
 
 from __future__ import annotations
 
 import collections
+from abc import ABC
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Iterable
+    from typing import Any, ClassVar, Iterable
 
     from typing_extensions import Self
 
@@ -28,6 +38,56 @@ def tree() -> collections.defaultdict:
     return collections.defaultdict(tree)
 
 
+class ControlledDict(collections.UserDict, ABC):
+    """
+    A base dictionary class with configurable mutability.
+
+    Attributes:
+        allow_add (bool): Whether new keys can be added.
+        allow_del (bool): Whether existing keys can be deleted.
+        allow_update (bool): Whether existing keys can be updated.
+    """
+
+    allow_add: ClassVar[bool] = True
+    allow_del: ClassVar[bool] = True
+    allow_update: ClassVar[bool] = True
+
+    def __setitem__(self, key, value):
+        """Forbid set when self.ADD is False."""
+        if key not in self.data and not self.allow_add:
+            raise TypeError("Cannot add new key, because add is disabled.")
+
+        super().__setitem__(key, value)
+
+    # def __ior__(self, other):
+    #     # Handle the |= operator for dictionary merging
+    #     for key in other:
+    #         if key not in self.data and not self.ADD:
+    #             raise TypeError(
+    #                 f"Cannot add new key using |= operator: {key!r} because ADD is set to False"
+    #             )
+
+    #     return super().__ior__(other)
+
+    def update(self, *args, **kwargs):
+        # For each key in the provided dictionary, check if it's a new key
+        for key in dict(*args, **kwargs):
+            if key not in self.data and not self.allow_add:
+                raise KeyError(
+                    f"Cannot add new key using update: {key!r} because ADD is set to False"
+                )
+
+        super().update(*args, **kwargs)
+
+    def setdefault(self, key, default=None):
+        if key not in self.data and not self.allow_add:
+            raise TypeError(
+                f"Cannot add new key using setdefault: {key!r} because ADD is set to False"
+            )
+
+        return super().setdefault(key, default)
+
+
 class frozendict(dict):
     """
     A dictionary that does not permit changes. The naming
@@ -43,7 +103,7 @@ class frozendict(dict):
         dict.__init__(self, *args, **kwargs)
 
     def __setitem__(self, key: Any, val: Any) -> None:
-        raise TypeError(f"Cannot overwrite existing key: {str(key)}")
+        raise TypeError(f"{type(self).__name__} does not support item assignment")
 
     def update(self, *args, **kwargs) -> None:
         """
@@ -54,7 +114,7 @@ class frozendict(dict):
         raise TypeError(f"Cannot update a {self.__class__.__name__}")
 
 
-class Namespace(dict):
+class Namespace(dict):  # TODO: this name is a bit confusing, deprecate it?
     """A dictionary that does not permit changing its values."""
 
     def __init__(self, *args, **kwargs) -> None:

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -151,11 +151,11 @@ class MongoDict:
     a nested dict interactively (e.g. documents extracted from a MongoDB
     database).
 
-    >>> m = MongoDict({'a': {'b': 1}, 'x': 2})
-    >>> assert m.a.b == 1 and m.x == 2
-    >>> assert "a" in m and "b" in m.a
-    >>> m["a"]
-    {'b': 1}
+    >>> m_dct = MongoDict({"a": {"b": 1}, "x": 2})
+    >>> assert m_dct.a.b == 1 and m_dct.x == 2
+    >>> assert "a" in m_dct and "b" in m_dct.a
+    >>> m_dct["a"]
+    {"b": 1}
 
     Notes:
         Cannot inherit from ABC collections.Mapping because otherwise

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -43,7 +43,7 @@ class frozendict(dict):
         dict.__init__(self, *args, **kwargs)
 
     def __setitem__(self, key: Any, val: Any) -> None:
-        raise KeyError(f"Cannot overwrite existing key: {str(key)}")
+        raise TypeError(f"Cannot overwrite existing key: {str(key)}")
 
     def update(self, *args, **kwargs) -> None:
         """
@@ -51,7 +51,7 @@ class frozendict(dict):
             args: Passthrough arguments for standard dict.
             kwargs: Passthrough keyword arguments for standard dict.
         """
-        raise KeyError(f"Cannot update a {self.__class__.__name__}")
+        raise TypeError(f"Cannot update a {self.__class__.__name__}")
 
 
 class Namespace(dict):
@@ -67,7 +67,7 @@ class Namespace(dict):
 
     def __setitem__(self, key: Any, val: Any) -> None:
         if key in self:
-            raise KeyError(f"Cannot overwrite existing key: {key!s}")
+            raise TypeError(f"Cannot overwrite existing key: {key!s}")
 
         dict.__setitem__(self, key, val)
 
@@ -137,7 +137,7 @@ class FrozenAttrDict(frozendict):
                 raise AttributeError(str(exc))
 
     def __setattr__(self, name: str, value: Any) -> None:
-        raise KeyError(
+        raise TypeError(
             f"You cannot modify attribute {name} of {self.__class__.__name__}"
         )
 

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -213,7 +213,7 @@ class FrozenAttrDict(frozendict):
 
     def __getattribute__(self, name: str) -> Any:
         try:
-            return super().__getattribute__(name)
+            return object.__getattribute__(self, name)
         except AttributeError:
             return self[name]
 

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -200,15 +200,50 @@ class AttrDict(dict):
         super().__setitem__(key, value)
 
 
-class FrozenAttrDict(frozendict):
+class FrozenAttrDict(AttrDict):
     """
     A dictionary that:
         - Does not permit changes (add/update/delete).
         - Allow accessing values as `dct.key` in addition to
             the traditional way `dct["key"]`.
 
-    TODO:
+    TODO: I didn't manage to inherit from `frozendict` which would trigger a RecursionError.
     """
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Allow setting only during initialization."""
+        object.__setattr__(self, "_initialized", False)
+        super().__init__(*args, **kwargs)
+        object.__setattr__(self, "_initialized", True)
+
+    def __setattr__(self, key, value):
+        """Allow setting only during initialization."""
+        if getattr(self, "_initialized", True) and key != "_initialized":
+            raise TypeError(
+                f"{self.__class__.__name__} does not support item assignment."
+            )
+        super().__setattr__(key, value)
+
+    def __setitem__(self, key, value):
+        raise TypeError(f"{self.__class__.__name__} does not support item assignment.")
+
+    def update(self, *args, **kwargs):
+        raise TypeError(f"{self.__class__.__name__} does not support update.")
+
+    def clear(self):
+        raise TypeError(f"{self.__class__.__name__} does not support clear.")
+
+    def pop(self, key, *args):
+        raise TypeError(f"{self.__class__.__name__} does not support pop.")
+
+    def popitem(self):
+        raise TypeError(f"{self.__class__.__name__} does not support popitem.")
+
+    def __delitem__(self, key):
+        raise TypeError(f"{self.__class__.__name__} does not support deletion.")
+
+    def __delattr__(self, key):
+        raise TypeError(f"{self.__class__.__name__} does not support deletion.")
 
 
 class MongoDict:

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -161,10 +161,10 @@ class frozendict(ControlledDict):
 
 
 class Namespace(ControlledDict):  # TODO: this name is a bit confusing, deprecate it?
-    """A dictionary that does not permit changing its values."""
+    """A dictionary that does not permit update/delete its values (but allows add)."""
 
     allow_add: ClassVar[bool] = True
-    allow_del: ClassVar[bool] = True
+    allow_del: ClassVar[bool] = False
     allow_update: ClassVar[bool] = False
 
 
@@ -185,7 +185,7 @@ class AttrDict(dict):
         self.__dict__ = self
 
 
-class FrozenAttrDict(frozendict, AttrDict):  # TODO: fix inheritance
+class FrozenAttrDict(frozendict):  # TODO: fix inheritance
     """
     A dictionary that:
         - Does not permit changes (add/update/delete).

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -49,7 +49,7 @@ class ControlledDict(collections.UserDict, ABC):
         allow_update (bool): Whether existing keys can be updated.
 
     Configurable Operations:
-        This class allows controlling the following dictionary operations (refer to
+        This class allows controlling the following dict operations (refer to
         https://docs.python.org/3.13/library/stdtypes.html#mapping-types-dict for details):
 
         - Adding or updating items:
@@ -170,8 +170,8 @@ class Namespace(ControlledDict):  # TODO: this name is a bit confusing, deprecat
 
 class AttrDict(dict):
     """
-    Allows to access values as dct.key in addition
-    to the traditional way dct["key"]
+    Allow accessing values as `dct.key` in addition to
+    the traditional way `dct["key"]`.
 
     Examples:
         >>> dct = AttrDict(foo=1, bar=2)
@@ -181,52 +181,17 @@ class AttrDict(dict):
     """
 
     def __init__(self, *args, **kwargs) -> None:
-        """
-        Args:
-            args: Passthrough arguments for standard dict.
-            kwargs: Passthrough keyword arguments for standard dict.
-        """
-        super().__init__(*args, **kwargs)
+        super(AttrDict, self).__init__(*args, **kwargs)
         self.__dict__ = self
 
-    def copy(self) -> Self:
-        """
-        Returns:
-            Copy of AttrDict
-        """
-        newd = super().copy()
-        return self.__class__(**newd)
 
-
-class FrozenAttrDict(frozendict):
+class FrozenAttrDict(frozendict, AttrDict):  # TODO: fix inheritance
     """
     A dictionary that:
-        - Does not permit changes.
-        - Allows to access values as dct.key in addition
-          to the traditional way dct["key"]
+        - Does not permit changes (add/update/delete).
+        - Allow accessing values as `dct.key` in addition to
+            the traditional way `dct["key"]`.
     """
-
-    def __init__(self, *args, **kwargs) -> None:
-        """
-        Args:
-            args: Passthrough arguments for standard dict.
-            kwargs: Passthrough keyword arguments for standard dict.
-        """
-        super().__init__(*args, **kwargs)
-
-    def __getattribute__(self, name: str) -> Any:
-        try:
-            return super().__getattribute__(name)
-        except AttributeError:
-            try:
-                return self[name]
-            except KeyError as exc:
-                raise AttributeError(str(exc))
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        raise TypeError(
-            f"You cannot modify attribute {name} of {self.__class__.__name__}"
-        )
 
 
 class MongoDict:

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -306,7 +306,7 @@ def dict2namedtuple(*args, **kwargs) -> tuple:
         >>> assert tpl.foo == 1 and tpl.bar == "hello"
 
         >>> tpl = dict2namedtuple([("foo", 1), ("bar", "hello")])
-        >>> assert tpl[0] is tpl.foo and t[1] is tpl.bar
+        >>> assert tpl[0] is tpl.foo and tpl[1] is tpl.bar
 
     Warnings:
         - The order of the items in the namedtuple is not deterministic if

--- a/src/monty/design_patterns.py
+++ b/src/monty/design_patterns.py
@@ -7,8 +7,11 @@ from __future__ import annotations
 import inspect
 import os
 from functools import wraps
-from typing import Any, Dict, Hashable, Tuple, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 from weakref import WeakValueDictionary
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 def singleton(cls):
@@ -95,7 +98,7 @@ def cached_class(cls: type[Klass]) -> type[Klass]:
             orig_init(self, *args, **kwargs)
             self._initialized = True
 
-    def reduce(self: Any) -> Tuple[type, Tuple, Dict[str, Any]]:
+    def reduce(self: Any) -> tuple[type, tuple, dict[str, Any]]:
         for key, value in cache.items():
             if value is self:
                 cls, args = key

--- a/src/monty/fractions.py
+++ b/src/monty/fractions.py
@@ -5,7 +5,10 @@ Math functions.
 from __future__ import annotations
 
 import math
-from typing import Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Sequence
 
 
 def gcd(*numbers: int) -> int:

--- a/src/monty/functools.py
+++ b/src/monty/functools.py
@@ -11,8 +11,13 @@ import sys
 import tempfile
 from collections import namedtuple
 from functools import partial, wraps
-from typing import Any, Callable, Union
+from typing import TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from typing import Any, Callable, Union
+
+
+# _CacheInfo doesn't seem to be used
 _CacheInfo = namedtuple("_CacheInfo", ["hits", "misses", "maxsize", "currsize"])
 
 

--- a/src/monty/functools.py
+++ b/src/monty/functools.py
@@ -9,16 +9,11 @@ import pstats
 import signal
 import sys
 import tempfile
-from collections import namedtuple
 from functools import partial, wraps
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Union
-
-
-# _CacheInfo doesn't seem to be used
-_CacheInfo = namedtuple("_CacheInfo", ["hits", "misses", "maxsize", "currsize"])
 
 
 class _HashedSeq(list):  # pylint: disable=C0205

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -111,7 +111,7 @@ class TestControlledDict:
             dct.clear()
 
     def test_frozen_like(self):
-        """Make sure setter is allow at init time."""
+        """Make sure add and update are allowed at init time."""
         ControlledDict.allow_add = False
         ControlledDict.allow_update = False
 
@@ -167,12 +167,22 @@ def test_namespace_dict():
 
 def test_attr_dict():
     dct = AttrDict(foo=1, bar=2)
+
+    # Test get attribute
     assert dct.bar == 2
     assert dct["foo"] is dct.foo
 
-    # Test accessing values
+    # Test key not found error
+    with pytest.raises(KeyError, match="no-such-key"):
+        dct["no-such-key"]
+
+    # Test setter
     dct.bar = "hello"
     assert dct["bar"] == "hello"
+
+    # Test delete
+    del dct.bar
+    assert "bar" not in dct
 
 
 def test_frozen_attrdict():

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -197,24 +197,26 @@ def test_frozen_attrdict():
     dct = FrozenAttrDict({"hello": "world", 1: 2})
     assert isinstance(dct, UserDict)
 
+    # Test attribute-like operations
+    with pytest.raises(TypeError, match="does not support item assignment"):
+        dct.foo = "bar"
+
+    with pytest.raises(TypeError, match="does not support item assignment"):
+        dct.hello = "new"
+
+    with pytest.raises(TypeError, match="does not support item deletion"):
+        del dct.hello
+
     # Test get value
     assert dct["hello"] == "world"
     assert dct.hello == "world"
-    assert dct["hello"] is dct.hello
+    assert dct["hello"] is dct.hello  # identity check
 
     # Test adding item
     with pytest.raises(TypeError, match="add is disabled"):
         dct["foo"] = "bar"
-    with pytest.raises(
-        TypeError, match="FrozenAttrDict does not support item assignment"
-    ):
-        dct.foo = "bar"
 
     # Test modifying existing item
-    with pytest.raises(
-        TypeError, match="FrozenAttrDict does not support item assignment"
-    ):
-        dct.hello = "new"
     with pytest.raises(TypeError, match="update is disabled"):
         dct["hello"] = "new"
 
@@ -232,9 +234,6 @@ def test_frozen_attrdict():
     # Test delete
     with pytest.raises(TypeError, match="delete is disabled"):
         del dct["hello"]
-
-    with pytest.raises(TypeError, match="does not support item deletion"):
-        del dct.hello
 
     with pytest.raises(TypeError, match="delete is disabled"):
         dct.clear()

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from monty.collections import (
@@ -13,8 +11,6 @@ from monty.collections import (
     frozendict,
     tree,
 )
-
-TEST_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 
 
 def test_tree():

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 import os
+from collections import namedtuple
 
 import pytest
 
-from monty.collections import AttrDict, FrozenAttrDict, Namespace, frozendict, tree
+from monty.collections import (
+    AttrDict,
+    FrozenAttrDict,
+    Namespace,
+    dict2namedtuple,
+    frozendict,
+    tree,
+)
 
 TEST_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 
@@ -30,7 +38,7 @@ def test_frozendict():
 
 
 def test_namespace_dict():
-    dct = Namespace(foo="bar")
+    dct = Namespace(key="val")
     dct["hello"] = "world"
     assert dct["key"] == "val"
 
@@ -38,6 +46,8 @@ def test_namespace_dict():
         dct["key"] = "val"
     with pytest.raises(KeyError, match="Cannot overwrite existing key"):
         dct.update({"key": "val"})
+    with pytest.raises(KeyError, match="Cannot overwrite existing key"):
+        dct |= {"key": "val"}
 
 
 def test_attr_dict():
@@ -62,3 +72,23 @@ def test_frozen_attrdict():
     # Test modifying existing item
     with pytest.raises(KeyError, match="You cannot modify attribute"):
         dct.hello = "new"
+    with pytest.raises(KeyError, match="You cannot modify attribute"):
+        dct["hello"] = "new"
+
+
+def test_mongo_dict():
+    """TODO: add test"""
+
+
+def test_dict2namedtuple():
+    # Init from dict
+    tpl = dict2namedtuple(foo=1, bar="hello")
+    assert isinstance(tpl, tuple)
+    assert tpl.foo == 1 and tpl.bar == "hello"
+
+    # Init from list of tuples
+    tpl = dict2namedtuple([("foo", 1), ("bar", "hello")])
+    assert isinstance(tpl, tuple)
+    assert tpl[0] == 1
+    assert tpl[1] == "hello"
+    assert tpl[0] is tpl.foo and tpl[1] is tpl.bar

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -28,7 +28,7 @@ def test_tree():
 class TestControlledDict:
     def test_add_allowed(self):
         dct = ControlledDict(a=1)
-        dct.allow_add = True
+        dct._allow_add = True
 
         dct["b"] = 2
         assert dct["b"] == 2
@@ -41,7 +41,7 @@ class TestControlledDict:
 
     def test_add_disabled(self):
         dct = ControlledDict(a=1)
-        dct.allow_add = False
+        dct._allow_add = False
 
         with pytest.raises(TypeError, match="add is disabled"):
             dct["b"] = 2
@@ -54,7 +54,7 @@ class TestControlledDict:
 
     def test_update_allowed(self):
         dct = ControlledDict(a=1)
-        dct.allow_update = True
+        dct._allow_update = True
 
         dct["a"] = 2
         assert dct["a"] == 2
@@ -67,7 +67,7 @@ class TestControlledDict:
 
     def test_update_disabled(self):
         dct = ControlledDict(a=1)
-        dct.allow_update = False
+        dct._allow_update = False
 
         with pytest.raises(TypeError, match="update is disabled"):
             dct["a"] = 2
@@ -80,7 +80,7 @@ class TestControlledDict:
 
     def test_del_allowed(self):
         dct = ControlledDict(a=1, b=2, c=3, d=4)
-        dct.allow_del = True
+        dct._allow_del = True
 
         del dct["a"]
         assert "a" not in dct
@@ -96,7 +96,7 @@ class TestControlledDict:
 
     def test_del_disabled(self):
         dct = ControlledDict(a=1)
-        dct.allow_del = False
+        dct._allow_del = False
 
         with pytest.raises(TypeError, match="delete is disabled"):
             del dct["a"]
@@ -112,15 +112,15 @@ class TestControlledDict:
 
     def test_frozen_like(self):
         """Make sure add and update are allowed at init time."""
-        ControlledDict.allow_add = False
-        ControlledDict.allow_update = False
+        ControlledDict._allow_add = False
+        ControlledDict._allow_update = False
 
         dct = ControlledDict({"hello": "world"})
         assert isinstance(dct, UserDict)
         assert dct["hello"] == "world"
 
-        assert not dct.allow_add
-        assert not dct.allow_update
+        assert not dct._allow_add
+        assert not dct._allow_update
 
 
 def test_frozendict():
@@ -128,9 +128,9 @@ def test_frozendict():
     assert isinstance(dct, UserDict)
     assert dct["hello"] == "world"
 
-    assert not dct.allow_add
-    assert not dct.allow_update
-    assert not dct.allow_del
+    assert not dct._allow_add
+    assert not dct._allow_update
+    assert not dct._allow_del
 
     # Test setter
     with pytest.raises(TypeError, match="add is disabled"):
@@ -195,7 +195,7 @@ def test_attr_dict():
 
 def test_frozen_attrdict():
     dct = FrozenAttrDict({"hello": "world", 1: 2})
-    assert isinstance(dct, dict)
+    assert isinstance(dct, UserDict)
 
     # Test get value
     assert dct["hello"] == "world"
@@ -203,9 +203,7 @@ def test_frozen_attrdict():
     assert dct["hello"] is dct.hello
 
     # Test adding item
-    with pytest.raises(
-        TypeError, match="FrozenAttrDict does not support item assignment"
-    ):
+    with pytest.raises(TypeError, match="add is disabled"):
         dct["foo"] = "bar"
     with pytest.raises(
         TypeError, match="FrozenAttrDict does not support item assignment"
@@ -217,30 +215,28 @@ def test_frozen_attrdict():
         TypeError, match="FrozenAttrDict does not support item assignment"
     ):
         dct.hello = "new"
-    with pytest.raises(
-        TypeError, match="FrozenAttrDict does not support item assignment"
-    ):
+    with pytest.raises(TypeError, match="update is disabled"):
         dct["hello"] = "new"
 
     # Test update
-    with pytest.raises(TypeError, match="FrozenAttrDict does not support update"):
+    with pytest.raises(TypeError, match="update is disabled"):
         dct.update({"hello": "world"})
 
     # Test pop
-    with pytest.raises(TypeError, match="FrozenAttrDict does not support pop"):
+    with pytest.raises(TypeError, match="delete is disabled"):
         dct.pop("hello")
 
-    with pytest.raises(TypeError, match="FrozenAttrDict does not support popitem"):
+    with pytest.raises(TypeError, match="delete is disabled"):
         dct.popitem()
 
     # Test delete
-    with pytest.raises(TypeError, match="FrozenAttrDict does not support deletion"):
+    with pytest.raises(TypeError, match="delete is disabled"):
         del dct["hello"]
 
-    with pytest.raises(TypeError, match="FrozenAttrDict does not support deletion"):
+    with pytest.raises(TypeError, match="does not support item deletion"):
         del dct.hello
 
-    with pytest.raises(TypeError, match="FrozenAttrDict does not support clear"):
+    with pytest.raises(TypeError, match="delete is disabled"):
         dct.clear()
 
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -44,17 +44,49 @@ class TestControlledDict:
         dct = ControlledDict(a=1)
         dct.allow_add = False
 
-        with pytest.raises(TypeError):  # TODO: add msg
+        with pytest.raises(TypeError, match="allow_add is set to False"):
             dct["b"] = 2
 
-        with pytest.raises(TypeError):  # TODO: add msg
-            dct.update(a=2)
+        with pytest.raises(TypeError, match="allow_add is set to False"):
+            dct.update(b=2)
 
-        with pytest.raises(TypeError):  # TODO: add msg
-            dct.setdefault("a", 2)
+        with pytest.raises(TypeError, match="allow_add is set to False"):
+            dct.setdefault("c", 2)
 
-        with pytest.raises(TypeError):  # TODO: add msg
-            dct |= {"b": 2}
+        with pytest.raises(TypeError, match="allow_add is set to False"):
+            dct |= {"d": 2}
+
+    def test_update_allowed(self):
+        dct = ControlledDict(a=1)
+        dct.allow_update = True
+
+        dct["a"] = 2
+        assert dct["a"] == 2
+
+        dct |= {"a": 3}
+        assert dct["a"] == 3
+
+        dct.update({"a": 4})
+        assert dct["a"] == 4
+
+        dct.setdefault("a", 5)  # existing key
+        assert dct["a"] == 4
+
+    def test_update_disabled(self):
+        dct = ControlledDict(a=1)
+        dct.allow_update = False
+
+        with pytest.raises(TypeError, match="allow_update is set to False"):
+            dct["a"] = 2
+
+        with pytest.raises(TypeError, match="allow_update is set to False"):
+            dct.update({"a": 3})
+
+        with pytest.raises(TypeError, match="allow_update is set to False"):
+            dct |= {"a": 4}
+
+        with pytest.raises(TypeError, match="allow_update is set to False"):
+            dct.setdefault("a", 5)
 
     def test_del_allowed(self):
         dct = ControlledDict(a=1, b=2, c=3, d=4)
@@ -76,37 +108,17 @@ class TestControlledDict:
         dct = ControlledDict(a=1)
         dct.allow_del = False
 
-        with pytest.raises(TypeError):  # TODO: add msg
+        with pytest.raises(TypeError, match="delete is disabled"):
             del dct["a"]
 
-        with pytest.raises(TypeError):  # TODO: add msg
+        with pytest.raises(TypeError, match="delete is disabled"):
             dct.pop("a")
 
-        with pytest.raises(TypeError):  # TODO: add msg
+        with pytest.raises(TypeError, match="delete is disabled"):
             dct.popitem()
 
-        with pytest.raises(TypeError):  # TODO: add msg
+        with pytest.raises(TypeError, match="delete is disabled"):
             dct.clear()
-
-    def test_update_allowed(self):
-        dct = ControlledDict(a=1)
-        dct.allow_update = True
-
-        dct["a"] = 2
-        assert dct["a"] == 2
-
-        dct |= {"a": 3}
-        assert dct["a"] == 3
-
-    def test_update_disabled(self):
-        dct = ControlledDict(a=1)
-        dct.allow_update = False
-
-        with pytest.raises(TypeError):  # TODO: add msg
-            dct["a"] = 2
-
-        with pytest.raises(TypeError):  # TODO: add msg
-            dct |= {"a": 3}
 
 
 def test_frozendict():

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -164,6 +164,10 @@ def test_namespace_dict():
     with pytest.raises(TypeError, match="update is disabled"):
         dct.update({"key": "val"})
 
+    # Test delete (not allowed)
+    with pytest.raises(TypeError, match="delete is disabled"):
+        del dct["key"]
+
 
 def test_attr_dict():
     dct = AttrDict(foo=1, bar=2)
@@ -187,7 +191,7 @@ def test_attr_dict():
 
 def test_frozen_attrdict():
     dct = FrozenAttrDict({"hello": "world", 1: 2})
-    assert isinstance(dct, dict)
+    assert isinstance(dct, UserDict)
     assert dct["hello"] == "world"
     assert dct.hello == "world"
     assert dct["hello"] is dct.hello

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -22,27 +22,34 @@ def test_tree():
     assert x["a"]["b"]["c"]["d"] == 1
 
 
-def test_frozendict():
+def test_frozendict():  # DEBUG
     dct = frozendict({"hello": "world"})
+    assert isinstance(dct, dict)
     assert dct["hello"] == "world"
 
-    with pytest.raises(KeyError, match="Cannot overwrite existing key"):
+    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
         dct["key"] == "val"
 
-    with pytest.raises(KeyError, match="Cannot overwrite existing key"):
-        dct.update(key="value")
+    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
+        dct.update(key="val")
+
+    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
+        dct |= {"key": "val"}
 
 
-def test_namespace_dict():
+def test_namespace_dict():  # DEBUG
     dct = Namespace(key="val")
+    assert isinstance(dct, dict)
     dct["hello"] = "world"
     assert dct["key"] == "val"
 
-    with pytest.raises(KeyError, match="Cannot overwrite existing key"):
+    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
         dct["key"] = "val"
-    with pytest.raises(KeyError, match="Cannot overwrite existing key"):
+
+    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
         dct.update({"key": "val"})
-    with pytest.raises(KeyError, match="Cannot overwrite existing key"):
+
+    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
         dct |= {"key": "val"}
 
 
@@ -56,21 +63,23 @@ def test_attr_dict():
     assert dct["bar"] == "hello"
 
 
-def test_frozen_attrdict():
+def test_frozen_attrdict():  # DEBUG
     dct = FrozenAttrDict({"hello": "world", 1: 2})
+    assert isinstance(dct, dict)
     assert dct["hello"] == "world"
     assert dct.hello == "world"
+    assert dct["hello"] is dct.hello
 
     # Test adding item
-    with pytest.raises(KeyError, match="You cannot modify attribute"):
+    with pytest.raises(TypeError, match="You cannot modify attribute"):
         dct["foo"] = "bar"
-    with pytest.raises(KeyError, match="You cannot modify attribute"):
+    with pytest.raises(TypeError, match="You cannot modify attribute"):
         dct.foo = "bar"
 
     # Test modifying existing item
-    with pytest.raises(KeyError, match="You cannot modify attribute"):
+    with pytest.raises(TypeError, match="You cannot modify attribute"):
         dct.hello = "new"
-    with pytest.raises(KeyError, match="You cannot modify attribute"):
+    with pytest.raises(TypeError, match="You cannot modify attribute"):
         dct["hello"] = "new"
 
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -31,14 +31,11 @@ class TestControlledDict:
         dct["b"] = 2
         assert dct["b"] == 2
 
-        dct |= {"c": 3}
-        assert dct["c"] == 3
+        dct.update(d=3)
+        assert dct["d"] == 3
 
-        dct.update(d=4)
-        assert dct["d"] == 4
-
-        dct.setdefault("e", 5)
-        assert dct["e"] == 5
+        dct.setdefault("e", 4)
+        assert dct["e"] == 4
 
     def test_add_disabled(self):
         dct = ControlledDict(a=1)
@@ -53,9 +50,6 @@ class TestControlledDict:
         with pytest.raises(TypeError, match="allow_add is set to False"):
             dct.setdefault("c", 2)
 
-        with pytest.raises(TypeError, match="allow_add is set to False"):
-            dct |= {"d": 2}
-
     def test_update_allowed(self):
         dct = ControlledDict(a=1)
         dct.allow_update = True
@@ -63,14 +57,11 @@ class TestControlledDict:
         dct["a"] = 2
         assert dct["a"] == 2
 
-        dct |= {"a": 3}
+        dct.update({"a": 3})
         assert dct["a"] == 3
 
-        dct.update({"a": 4})
-        assert dct["a"] == 4
-
-        dct.setdefault("a", 5)  # existing key
-        assert dct["a"] == 4
+        dct.setdefault("a", 4)  # existing key
+        assert dct["a"] == 3
 
     def test_update_disabled(self):
         dct = ControlledDict(a=1)
@@ -83,10 +74,7 @@ class TestControlledDict:
             dct.update({"a": 3})
 
         with pytest.raises(TypeError, match="allow_update is set to False"):
-            dct |= {"a": 4}
-
-        with pytest.raises(TypeError, match="allow_update is set to False"):
-            dct.setdefault("a", 5)
+            dct.setdefault("a", 4)
 
     def test_del_allowed(self):
         dct = ControlledDict(a=1, b=2, c=3, d=4)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -195,22 +195,53 @@ def test_attr_dict():
 
 def test_frozen_attrdict():
     dct = FrozenAttrDict({"hello": "world", 1: 2})
-    assert isinstance(dct, UserDict)
+    assert isinstance(dct, dict)
+
+    # Test get value
     assert dct["hello"] == "world"
     assert dct.hello == "world"
     assert dct["hello"] is dct.hello
 
     # Test adding item
-    with pytest.raises(TypeError, match="You cannot modify attribute"):
+    with pytest.raises(
+        TypeError, match="FrozenAttrDict does not support item assignment"
+    ):
         dct["foo"] = "bar"
-    with pytest.raises(TypeError, match="You cannot modify attribute"):
+    with pytest.raises(
+        TypeError, match="FrozenAttrDict does not support item assignment"
+    ):
         dct.foo = "bar"
 
     # Test modifying existing item
-    with pytest.raises(TypeError, match="You cannot modify attribute"):
+    with pytest.raises(
+        TypeError, match="FrozenAttrDict does not support item assignment"
+    ):
         dct.hello = "new"
-    with pytest.raises(TypeError, match="You cannot modify attribute"):
+    with pytest.raises(
+        TypeError, match="FrozenAttrDict does not support item assignment"
+    ):
         dct["hello"] = "new"
+
+    # Test update
+    with pytest.raises(TypeError, match="FrozenAttrDict does not support update"):
+        dct.update({"hello": "world"})
+
+    # Test pop
+    with pytest.raises(TypeError, match="FrozenAttrDict does not support pop"):
+        dct.pop("hello")
+
+    with pytest.raises(TypeError, match="FrozenAttrDict does not support popitem"):
+        dct.popitem()
+
+    # Test delete
+    with pytest.raises(TypeError, match="FrozenAttrDict does not support deletion"):
+        del dct["hello"]
+
+    with pytest.raises(TypeError, match="FrozenAttrDict does not support deletion"):
+        del dct.hello
+
+    with pytest.raises(TypeError, match="FrozenAttrDict does not support clear"):
+        dct.clear()
 
 
 def test_mongo_dict():

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -43,13 +43,13 @@ class TestControlledDict:
         dct = ControlledDict(a=1)
         dct.allow_add = False
 
-        with pytest.raises(TypeError, match="allow_add is set to False"):
+        with pytest.raises(TypeError, match="add is disabled"):
             dct["b"] = 2
 
-        with pytest.raises(TypeError, match="allow_add is set to False"):
+        with pytest.raises(TypeError, match="add is disabled"):
             dct.update(b=2)
 
-        with pytest.raises(TypeError, match="allow_add is set to False"):
+        with pytest.raises(TypeError, match="add is disabled"):
             dct.setdefault("c", 2)
 
     def test_update_allowed(self):
@@ -69,13 +69,13 @@ class TestControlledDict:
         dct = ControlledDict(a=1)
         dct.allow_update = False
 
-        with pytest.raises(TypeError, match="allow_update is set to False"):
+        with pytest.raises(TypeError, match="update is disabled"):
             dct["a"] = 2
 
-        with pytest.raises(TypeError, match="allow_update is set to False"):
+        with pytest.raises(TypeError, match="update is disabled"):
             dct.update({"a": 3})
 
-        with pytest.raises(TypeError, match="allow_update is set to False"):
+        with pytest.raises(TypeError, match="update is disabled"):
             dct.setdefault("a", 4)
 
     def test_del_allowed(self):
@@ -133,11 +133,11 @@ def test_frozendict():
     assert not dct.allow_del
 
     # Test setter
-    with pytest.raises(TypeError, match="allow_add is set to False"):
+    with pytest.raises(TypeError, match="add is disabled"):
         dct["key"] = "val"
 
     # Test update
-    with pytest.raises(TypeError, match="allow_add is set to False"):
+    with pytest.raises(TypeError, match="add is disabled"):
         dct.update(key="val")
 
     # Test pop
@@ -151,7 +151,7 @@ def test_frozendict():
 
 def test_namespace_dict():
     dct = Namespace(key="val")
-    assert isinstance(dct, dict)
+    assert isinstance(dct, UserDict)
     dct["hello"] = "world"
     assert dct["key"] == "val"
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -9,47 +9,56 @@ from monty.collections import AttrDict, FrozenAttrDict, Namespace, frozendict, t
 TEST_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 
 
-class TestFrozenDict:
-    def test_frozen_dict(self):
-        d = frozendict({"hello": "world"})
-        with pytest.raises(KeyError):
-            d["k"] == "v"
-        assert d["hello"] == "world"
-
-    def test_namespace_dict(self):
-        d = Namespace(foo="bar")
-        d["hello"] = "world"
-        assert d["foo"] == "bar"
-        with pytest.raises(KeyError):
-            d.update({"foo": "spam"})
-
-    def test_attr_dict(self):
-        d = AttrDict(foo=1, bar=2)
-        assert d.bar == 2
-        assert d["foo"] == d.foo
-        d.bar = "hello"
-        assert d["bar"] == "hello"
-
-    def test_frozen_attrdict(self):
-        d = FrozenAttrDict({"hello": "world", 1: 2})
-        assert d["hello"] == "world"
-        assert d.hello == "world"
-        with pytest.raises(KeyError):
-            d["updating"] == 2
-
-        with pytest.raises(KeyError):
-            d["foo"] = "bar"
-        with pytest.raises(KeyError):
-            d.foo = "bar"
-        with pytest.raises(KeyError):
-            d.hello = "new"
+def test_tree():
+    x = tree()
+    x["a"]["b"]["c"]["d"] = 1
+    assert "b" in x["a"]
+    assert "c" not in x["a"]
+    assert "c" in x["a"]["b"]
+    assert x["a"]["b"]["c"]["d"] == 1
 
 
-class TestTree:
-    def test_tree(self):
-        x = tree()
-        x["a"]["b"]["c"]["d"] = 1
-        assert "b" in x["a"]
-        assert "c" not in x["a"]
-        assert "c" in x["a"]["b"]
-        assert x["a"]["b"]["c"]["d"] == 1
+def test_frozendict():
+    dct = frozendict({"hello": "world"})
+    assert dct["hello"] == "world"
+
+    with pytest.raises(KeyError, match="Cannot overwrite existing key"):
+        dct["key"] == "val"
+
+    with pytest.raises(KeyError, match="Cannot overwrite existing key"):
+        dct.update(key="value")
+
+
+def test_namespace_dict():
+    dct = Namespace(foo="bar")
+    dct["hello"] = "world"
+    assert dct["key"] == "val"
+
+    with pytest.raises(KeyError, match="Cannot overwrite existing key"):
+        dct["key"] = "val"
+    with pytest.raises(KeyError, match="Cannot overwrite existing key"):
+        dct.update({"key": "val"})
+
+
+def test_attr_dict():
+    dct = AttrDict(foo=1, bar=2)
+    assert dct.bar == 2
+    assert dct["foo"] is dct.foo
+    dct.bar = "hello"
+    assert dct["bar"] == "hello"
+
+
+def test_frozen_attrdict():
+    dct = FrozenAttrDict({"hello": "world", 1: 2})
+    assert dct["hello"] == "world"
+    assert dct.hello == "world"
+
+    # Test adding item
+    with pytest.raises(KeyError, match="You cannot modify attribute"):
+        dct["foo"] = "bar"
+    with pytest.raises(KeyError, match="You cannot modify attribute"):
+        dct.foo = "bar"
+
+    # Test modifying existing item
+    with pytest.raises(KeyError, match="You cannot modify attribute"):
+        dct.hello = "new"

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import os
-from collections import namedtuple
 
 import pytest
 
 from monty.collections import (
     AttrDict,
     FrozenAttrDict,
+    MongoDict,
     Namespace,
     dict2namedtuple,
     frozendict,
@@ -54,6 +54,8 @@ def test_attr_dict():
     dct = AttrDict(foo=1, bar=2)
     assert dct.bar == 2
     assert dct["foo"] is dct.foo
+
+    # Test accessing values
     dct.bar = "hello"
     assert dct["bar"] == "hello"
 
@@ -77,7 +79,12 @@ def test_frozen_attrdict():
 
 
 def test_mongo_dict():
-    """TODO: add test"""
+    m_dct = MongoDict({"a": {"b": 1}, "x": 2})
+    assert m_dct.a.b == 1
+    assert m_dct.x == 2
+    assert "a" in m_dct
+    assert "b" in m_dct.a
+    assert m_dct["a"] == {"b": 1}
 
 
 def test_dict2namedtuple():

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -188,6 +188,10 @@ def test_attr_dict():
     del dct.bar
     assert "bar" not in dct
 
+    # Test builtin dict method shadowing
+    with pytest.warns(UserWarning, match="shadows dict method"):
+        dct["update"] = "value"
+
 
 def test_frozen_attrdict():
     dct = FrozenAttrDict({"hello": "world", 1: 2})

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -152,17 +152,17 @@ def test_frozendict():
 def test_namespace_dict():
     dct = Namespace(key="val")
     assert isinstance(dct, UserDict)
+
+    # Test setter
     dct["hello"] = "world"
     assert dct["key"] == "val"
 
-    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
+    # Test update (not allowed)
+    with pytest.raises(TypeError, match="update is disabled"):
         dct["key"] = "val"
 
-    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
+    with pytest.raises(TypeError, match="update is disabled"):
         dct.update({"key": "val"})
-
-    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
-        dct |= {"key": "val"}
 
 
 def test_attr_dict():

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import UserDict
+
 import pytest
 
 from monty.collections import (
@@ -108,32 +110,42 @@ class TestControlledDict:
         with pytest.raises(TypeError, match="delete is disabled"):
             dct.clear()
 
+    def test_frozen_like(self):
+        """Make sure setter is allow at init time."""
+        ControlledDict.allow_add = False
+        ControlledDict.allow_update = False
+
+        dct = ControlledDict({"hello": "world"})
+        assert isinstance(dct, UserDict)
+        assert dct["hello"] == "world"
+
+        assert not dct.allow_add
+        assert not dct.allow_update
+
 
 def test_frozendict():
     dct = frozendict({"hello": "world"})
-    assert isinstance(dct, dict)
+    assert isinstance(dct, UserDict)
     assert dct["hello"] == "world"
 
+    assert not dct.allow_add
+    assert not dct.allow_update
+    assert not dct.allow_del
+
     # Test setter
-    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
-        dct["key"] == "val"
+    with pytest.raises(TypeError, match="allow_add is set to False"):
+        dct["key"] = "val"
 
     # Test update
-    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
+    with pytest.raises(TypeError, match="allow_add is set to False"):
         dct.update(key="val")
 
-    # Test inplace-or (|=)
-    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
-        dct |= {"key": "val"}
-
-    # TODO: from this point we need a different error message
-
     # Test pop
-    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
+    with pytest.raises(TypeError, match="delete is disabled"):
         dct.pop("key")
 
     # Test delete
-    with pytest.raises(TypeError, match="Cannot overwrite existing key"):
+    with pytest.raises(TypeError, match="delete is disabled"):
         del dct["key"]
 
 


### PR DESCRIPTION
### Summary

- Fix custom dict overriding in `collections`
- When trying to modify a frozen dict, raise `TypeError` instead of `KeyError`, in our case, it's "the setter being called on the inappropriate type" instead of "key missing":
    - For example: When trying to modify a `frozenset` it would raise: `TypeError: 'frozenset' object does not support item assignment`:
    - [KeyError: Raised when a mapping (dictionary) key is not found in the set of existing keys.](https://docs.python.org/3/library/exceptions.html#TypeError)
    - [TypeError: Raised when an operation or function is applied to an object of inappropriate type.](https://docs.python.org/3/library/exceptions.html#TypeError)

---

### Custom dicts don't seem to be overridden correctly/fully in `collections`
https://docs.python.org/3/library/stdtypes.html#mapping-types-dict

### `frozendict`
- [x] When trying to add **new** key-value, wrong error message `TypeError: Cannot overwrite existing key: key` 
- [x] `del/pop` method is not overridden, key could be removed

### `FrozenAttrDict`

```python
from monty.collections import FrozenAttrDict

dct = FrozenAttrDict(a=1)
dct["b"] = 2  # >>> KeyError: 'Cannot overwrite existing key: b' (misleading error msg, "b" is not existing key)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `ControlledDict` class for enhanced control over dictionary operations.
	- Added new tests for `ControlledDict`, `MongoDict`, and `dict2namedtuple`.

- **Bug Fixes**
	- Improved error handling for operations in `ControlledDict`, `frozendict`, and `Namespace`.

- **Documentation**
	- Enhanced docstrings for clarity and usage guidance across various classes.

- **Tests**
	- Refactored test suite to a function-based structure, improving organization and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->