### PR TITLE
Add case-insensitive dictionary `CaseInsensitiveDict[Base/Upper/Lower]` to `collections`

### DIFF
--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -243,6 +243,12 @@ class CaseInsensitiveDictUpper(CaseInsensitiveDictBase):
         return key.upper() if isinstance(key, str) else key
 
 
+class CaseInsensitiveDictLower(CaseInsensitiveDictBase):
+    @staticmethod
+    def _converter(key: Any) -> Any:
+        return key.lower() if isinstance(key, str) else key
+
+
 class MongoDict:
     """
     This dict-like object allows one to access the entries in a nested dict as

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -204,7 +204,7 @@ class CaseInsensitiveDictBase(collections.UserDict, ABC):
         """Checks if a case-insensitive key is `in` the dictionary."""
         return super().__contains__(self._converter(key))
 
-    def __ior__(self, other: Mapping | Iterable, /) -> Self:
+    def __ior__(self, other: Mapping | Iterable, /) -> Self:  # type: ignore[override]
         """The `|=` operator."""
         self.update(other)
         return self

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import collections
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING, Mapping, overload
 
 if TYPE_CHECKING:
     from typing import Any, Iterable
@@ -204,15 +204,24 @@ class CaseInsensitiveDictBase(collections.UserDict, ABC):
         """Checks if a case-insensitive key is `in` the dictionary."""
         return super().__contains__(self._converter(key))
 
-    def __ior__(self, other: Mapping) -> Self:
-        """The |= operator."""
+    def __ior__(self, other: Mapping | Iterable, /) -> Self:
+        """The `|=` operator."""
         self.update(other)
         return self
+
+    def __or__(self, other: Mapping[Any, Any]) -> Self:
+        """The `|` operator."""
+        if not isinstance(other, Mapping):
+            return NotImplemented
+
+        new_dict = type(self)(self)
+        new_dict.update(other)
+        return new_dict
 
     def setdefault(self, key: Any, default: Any = None) -> Any:
         return super().setdefault(self._converter(key), default)
 
-    def update(self, *args: Iterable[Mapping], **kwargs: Any) -> None:
+    def update(self, *args, **kwargs: Any) -> None:
         if args:
             for mapping in args:
                 if isinstance(mapping, Mapping):

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -154,7 +154,7 @@ class CaseInsensitiveDictBase(collections.UserDict, ABC):
             `__delitem__`, `del dct[key]`, `pop(key)`
 
         - Other operations:
-            getter (`__getitem__`)
+            getter (`__getitem__`, `get`)
             membership check with `in` (`__contains__`)
 
     Subclasses must implement the `_converter` static method to define

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -4,6 +4,7 @@ import pytest
 
 from monty.collections import (
     AttrDict,
+    CaseInsensitiveDictLower,
     CaseInsensitiveDictUpper,
     FrozenAttrDict,
     Namespace,
@@ -193,6 +194,23 @@ class TestCaseInsensitiveDictUpper:
         popped_value = self.upper_dict.pop("non-existent", "default")
         assert popped_value == "default"
         assert "non-existent" not in self.upper_dict
+
+
+class TestCaseInsensitiveDictLower:
+    """Most case-insensitive dict behaviour would be tested in
+    `TestCaseInsensitiveDictUpper` to avoid duplicate.
+    """
+
+    def test_converter(self):
+        str_key = "Capitalized"
+        assert CaseInsensitiveDictLower._converter(str_key) == "capitalized"
+
+        # Test non-string object handling (should be returned as is)
+        int_key = 1
+        assert CaseInsensitiveDictLower._converter(int_key) == 1
+
+        tup_key = (1, 2, 3)
+        assert CaseInsensitiveDictLower._converter(tup_key) == (1, 2, 3)
 
 
 class TestTree:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -140,6 +140,29 @@ class TestCaseInsensitiveDictUpper:
         assert self.upper_dict["F"] == 8
         assert self.upper_dict["f"] == 8
 
+    def test_or_operator(self):
+        # Test with another CaseInsensitiveDictUpper
+        other = CaseInsensitiveDictUpper({"E": 7, "F": 8})
+        result = self.upper_dict | other
+        assert isinstance(result, CaseInsensitiveDictUpper)
+        assert result["E"] == 7
+        assert result["e"] == 7
+        assert result["F"] == 8
+        assert result["f"] == 8
+        assert result["HI"] == "world"
+        assert result["hi"] == "world"
+
+        # Test with a regular dict
+        other = {"g": 9, "H": 10}
+        result = self.upper_dict | other
+        assert isinstance(result, CaseInsensitiveDictUpper)
+        assert result["G"] == 9
+        assert result["g"] == 9
+        assert result["H"] == 10
+        assert result["h"] == 10
+        assert result["HI"] == "world"
+        assert result["hi"] == "world"
+
     def test_setdefault(self):
         assert self.upper_dict.setdefault("g", 9) == 9
         assert self.upper_dict["G"] == 9

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -52,6 +52,28 @@ class TestCaseInsensitiveDictUpper:
     def setup_method(self):
         self.upper_dict = CaseInsensitiveDictUpper({"HI": "world"})
 
+    def test_init(self):
+        # Test init from Mapping
+        dct = CaseInsensitiveDictUpper({"key1": "value1", "Key2": "value2"})
+        assert dct["key1"] == "value1"
+        assert dct["KEY1"] == "value1"
+        assert dct["Key2"] == "value2"
+        assert dct["key2"] == "value2"
+
+        # Test init from Iterable
+        dct = CaseInsensitiveDictUpper([("key1", "value1"), ("Key2", "value2")])
+        assert dct["key1"] == "value1"
+        assert dct["KEY1"] == "value1"
+        assert dct["Key2"] == "value2"
+        assert dct["key2"] == "value2"
+
+        # Test init with kwargs
+        dct = CaseInsensitiveDictUpper(key1="value1", Key2="value2")
+        assert dct["key1"] == "value1"
+        assert dct["KEY1"] == "value1"
+        assert dct["Key2"] == "value2"
+        assert dct["key2"] == "value2"
+
     def test_converter(self):
         str_key = "upper"
         assert CaseInsensitiveDictUpper._converter(str_key) == "UPPER"
@@ -79,11 +101,35 @@ class TestCaseInsensitiveDictUpper:
         assert self.upper_dict["B"] == 2
 
     def test_update(self):
+        # Test with Mapping
         self.upper_dict.update({"c": 5, "D": 6})
         assert self.upper_dict["C"] == 5
         assert self.upper_dict["c"] == 5
         assert self.upper_dict["D"] == 6
         assert self.upper_dict["d"] == 6
+
+        # Test with Iterable
+        self.upper_dict.update([("e", 7), ("F", 8)])
+        assert self.upper_dict["E"] == 7
+        assert self.upper_dict["e"] == 7
+        assert self.upper_dict["F"] == 8
+        assert self.upper_dict["f"] == 8
+
+        # Test with kwargs
+        self.upper_dict.update(g=9, H=10)
+        assert self.upper_dict["G"] == 9
+        assert self.upper_dict["g"] == 9
+        assert self.upper_dict["H"] == 10
+        assert self.upper_dict["h"] == 10
+
+        # Test combined
+        self.upper_dict.update({"I": 11}, j=12, k=13)
+        assert self.upper_dict["I"] == 11
+        assert self.upper_dict["i"] == 11
+        assert self.upper_dict["J"] == 12
+        assert self.upper_dict["j"] == 12
+        assert self.upper_dict["K"] == 13
+        assert self.upper_dict["k"] == 13
 
     def test_ior_operator(self):
         self.upper_dict |= {"e": 7, "F": 8}

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -99,6 +99,8 @@ class TestCaseInsensitiveDictUpper:
         self.upper_dict["B"] = 2
         assert self.upper_dict["b"] == 2
         assert self.upper_dict["B"] == 2
+        assert self.upper_dict.get("b") == 2
+        assert self.upper_dict.get("B") == 2
 
     def test_update(self):
         # Test with Mapping

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -212,6 +212,28 @@ class TestCaseInsensitiveDictLower:
         tup_key = (1, 2, 3)
         assert CaseInsensitiveDictLower._converter(tup_key) == (1, 2, 3)
 
+    def test_init(self):
+        # Test init from Mapping
+        dct = CaseInsensitiveDictLower({"key1": "value1", "Key2": "value2"})
+        assert dct["key1"] == "value1"
+        assert dct["KEY1"] == "value1"
+        assert dct["Key2"] == "value2"
+        assert dct["key2"] == "value2"
+
+        # Test init from Iterable
+        dct = CaseInsensitiveDictLower([("key1", "value1"), ("Key2", "value2")])
+        assert dct["key1"] == "value1"
+        assert dct["KEY1"] == "value1"
+        assert dct["Key2"] == "value2"
+        assert dct["key2"] == "value2"
+
+        # Test init with kwargs
+        dct = CaseInsensitiveDictLower(key1="value1", Key2="value2")
+        assert dct["key1"] == "value1"
+        assert dct["KEY1"] == "value1"
+        assert dct["Key2"] == "value2"
+        assert dct["key2"] == "value2"
+
 
 class TestTree:
     def test_tree(self):

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -98,6 +98,33 @@ def test_CaseInsensitiveDictUpper():
     assert "G" in upper_dict
     assert "non-existent" not in upper_dict
 
+    # Test `__delitem__`
+    del upper_dict["hi"]
+    assert "hi" not in upper_dict
+    assert "HI" not in upper_dict
+
+    # Test `del dct[key]`
+    del upper_dict["b"]
+    assert "b" not in upper_dict
+    assert "B" not in upper_dict
+
+    # Test `pop(key)`
+    popped_value = upper_dict.pop("c")
+    assert popped_value == 5
+    assert "c" not in upper_dict
+    assert "C" not in upper_dict
+
+    # Test `pop(key)` with default value (key exists)
+    popped_value = upper_dict.pop("d", "default")
+    assert popped_value == 6
+    assert "d" not in upper_dict
+    assert "D" not in upper_dict
+
+    # Test `pop(key)` with default value (key doesn't exist)
+    popped_value = upper_dict.pop("non-existent", "default")
+    assert popped_value == "default"
+    assert "non-existent" not in upper_dict
+
 
 class TestTree:
     def test_tree(self):

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -164,6 +164,10 @@ class TestCaseInsensitiveDictUpper:
         assert result["HI"] == "world"
         assert result["hi"] == "world"
 
+        # Test with not-supported type
+        with pytest.raises(TypeError, match="unsupported operand type"):
+            self.upper_dict | "hello"
+
     def test_setdefault(self):
         assert self.upper_dict.setdefault("g", 9) == 9
         assert self.upper_dict["G"] == 9

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -48,82 +48,80 @@ class TestFrozenDict:
             d.hello = "new"
 
 
-def test_CaseInsensitiveDictUpper():
-    upper_dict = CaseInsensitiveDictUpper({"HI": "world"})
-    assert "hi" in upper_dict
-    assert upper_dict["HI"] == "world"
-    assert upper_dict["hi"] == "world"
+class TestCaseInsensitiveDictUpper:
+    def setup_method(self):
+        self.upper_dict = CaseInsensitiveDictUpper({"HI": "world"})
 
-    # Test setter and getter
-    upper_dict["a"] = 1
-    assert upper_dict["a"] == 1
-    assert upper_dict["A"] == 1
+    def test_converter(self):
+        str_key = "upper"
+        assert CaseInsensitiveDictUpper._converter(str_key) == "UPPER"
 
-    upper_dict["B"] = 2  # upper case
-    assert upper_dict["b"] == 2
-    assert upper_dict["B"] == 2
+        # Test non-string object handling (should be returned as is)
+        int_key = 1
+        assert CaseInsensitiveDictUpper._converter(int_key) == 1
 
-    # Test update with setter
-    upper_dict["B"] = 3
-    assert upper_dict["b"] == 3
-    assert upper_dict["B"] == 3
+        tup_key = (1, 2, 3)
+        assert CaseInsensitiveDictUpper._converter(tup_key) == (1, 2, 3)
 
-    upper_dict["b"] = 4
-    assert upper_dict["b"] == 4
-    assert upper_dict["B"] == 4
+    def test_membership(self):
+        assert "hi" in self.upper_dict
+        assert "HI" in self.upper_dict
+        assert self.upper_dict["HI"] == "world"
+        assert self.upper_dict["hi"] == "world"
 
-    # Test update with `update`
-    upper_dict.update({"c": 5, "D": 6})
-    assert upper_dict["C"] == 5
-    assert upper_dict["c"] == 5
-    assert upper_dict["D"] == 6
-    assert upper_dict["d"] == 6
+    def test_setter_and_getter(self):
+        self.upper_dict["a"] = 1
+        assert self.upper_dict["a"] == 1
+        assert self.upper_dict["A"] == 1
 
-    # Test update with `|=`
-    upper_dict |= {"e": 7, "F": 8}
-    assert upper_dict["E"] == 7
-    assert upper_dict["e"] == 7
-    assert upper_dict["F"] == 8
-    assert upper_dict["f"] == 8
+        self.upper_dict["B"] = 2
+        assert self.upper_dict["b"] == 2
+        assert self.upper_dict["B"] == 2
 
-    # Test `setdefault`
-    assert upper_dict.setdefault("g", 9) == 9  # Add new key
-    assert upper_dict["G"] == 9
-    assert upper_dict["g"] == 9
-    assert upper_dict.setdefault("g", 10) == 9  # Existing key remains unchanged
-    assert upper_dict["G"] == 9
+    def test_update(self):
+        self.upper_dict.update({"c": 5, "D": 6})
+        assert self.upper_dict["C"] == 5
+        assert self.upper_dict["c"] == 5
+        assert self.upper_dict["D"] == 6
+        assert self.upper_dict["d"] == 6
 
-    # Test membership check with `in`
-    assert "g" in upper_dict
-    assert "G" in upper_dict
-    assert "non-existent" not in upper_dict
+    def test_ior_operator(self):
+        self.upper_dict |= {"e": 7, "F": 8}
+        assert self.upper_dict["E"] == 7
+        assert self.upper_dict["e"] == 7
+        assert self.upper_dict["F"] == 8
+        assert self.upper_dict["f"] == 8
 
-    # Test `__delitem__`
-    del upper_dict["hi"]
-    assert "hi" not in upper_dict
-    assert "HI" not in upper_dict
+    def test_setdefault(self):
+        assert self.upper_dict.setdefault("g", 9) == 9
+        assert self.upper_dict["G"] == 9
+        assert self.upper_dict.setdefault("g", 10) == 9  # Unchanged
+        assert self.upper_dict["G"] == 9
 
-    # Test `del dct[key]`
-    del upper_dict["b"]
-    assert "b" not in upper_dict
-    assert "B" not in upper_dict
+    def test_delete_items(self):
+        # Test `__delitem__`
+        del self.upper_dict["hi"]
+        assert "hi" not in self.upper_dict
+        assert "HI" not in self.upper_dict
 
-    # Test `pop(key)`
-    popped_value = upper_dict.pop("c")
-    assert popped_value == 5
-    assert "c" not in upper_dict
-    assert "C" not in upper_dict
+        # Test `del dct[key]`
+        self.upper_dict["b"] = 4
+        del self.upper_dict["b"]
+        assert "b" not in self.upper_dict
+        assert "B" not in self.upper_dict
 
-    # Test `pop(key)` with default value (key exists)
-    popped_value = upper_dict.pop("d", "default")
-    assert popped_value == 6
-    assert "d" not in upper_dict
-    assert "D" not in upper_dict
+    def test_pop(self):
+        # Test `pop(key)`
+        self.upper_dict["c"] = 5
+        popped_value = self.upper_dict.pop("c")
+        assert popped_value == 5
+        assert "c" not in self.upper_dict
+        assert "C" not in self.upper_dict
 
-    # Test `pop(key)` with default value (key doesn't exist)
-    popped_value = upper_dict.pop("non-existent", "default")
-    assert popped_value == "default"
-    assert "non-existent" not in upper_dict
+        # Test `pop(key)` with default value
+        popped_value = self.upper_dict.pop("non-existent", "default")
+        assert popped_value == "default"
+        assert "non-existent" not in self.upper_dict
 
 
 class TestTree:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-import os
-
 import pytest
 
-from monty.collections import AttrDict, FrozenAttrDict, Namespace, frozendict, tree
-
-TEST_DIR = os.path.join(os.path.dirname(__file__), "test_files")
+from monty.collections import (
+    AttrDict,
+    CaseInsensitiveDictUpper,
+    FrozenAttrDict,
+    Namespace,
+    frozendict,
+    tree,
+)
 
 
 class TestFrozenDict:
@@ -43,6 +46,57 @@ class TestFrozenDict:
             d.foo = "bar"
         with pytest.raises(KeyError):
             d.hello = "new"
+
+
+def test_CaseInsensitiveDictUpper():
+    upper_dict = CaseInsensitiveDictUpper({"HI": "world"})
+    assert "hi" in upper_dict
+    assert upper_dict["HI"] == "world"
+    assert upper_dict["hi"] == "world"
+
+    # Test setter and getter
+    upper_dict["a"] = 1
+    assert upper_dict["a"] == 1
+    assert upper_dict["A"] == 1
+
+    upper_dict["B"] = 2  # upper case
+    assert upper_dict["b"] == 2
+    assert upper_dict["B"] == 2
+
+    # Test update with setter
+    upper_dict["B"] = 3
+    assert upper_dict["b"] == 3
+    assert upper_dict["B"] == 3
+
+    upper_dict["b"] = 4
+    assert upper_dict["b"] == 4
+    assert upper_dict["B"] == 4
+
+    # Test update with `update`
+    upper_dict.update({"c": 5, "D": 6})
+    assert upper_dict["C"] == 5
+    assert upper_dict["c"] == 5
+    assert upper_dict["D"] == 6
+    assert upper_dict["d"] == 6
+
+    # Test update with `|=`
+    upper_dict |= {"e": 7, "F": 8}
+    assert upper_dict["E"] == 7
+    assert upper_dict["e"] == 7
+    assert upper_dict["F"] == 8
+    assert upper_dict["f"] == 8
+
+    # Test `setdefault`
+    assert upper_dict.setdefault("g", 9) == 9  # Add new key
+    assert upper_dict["G"] == 9
+    assert upper_dict["g"] == 9
+    assert upper_dict.setdefault("g", 10) == 9  # Existing key remains unchanged
+    assert upper_dict["G"] == 9
+
+    # Test membership check with `in`
+    assert "g" in upper_dict
+    assert "G" in upper_dict
+    assert "non-existent" not in upper_dict
 
 
 class TestTree:


### PR DESCRIPTION
### Summary

- Add case-insensitive dictionary to `collections`, migrate `pymatgen` implementation of `Lobsterin` and `Incar`

### Performance Benchmark

**Init a `CaseInsensitiveDict` would be way more expensive than a standard dict** (a bare `UserDict` is less performant than standard dict), but lookup is almost instant (typical of a hash table).

Bare `UserDict` vs standard dict:
```
  Size    Dict Init Time (ms)    Dict Lookup Time (ms)    CI Dict Init Time (ms)    CI Dict Lookup Time (ms)
------  ---------------------  -----------------------  ------------------------  --------------------------
     1                  0.000                    0.000                     0.006                       0.000
    10                  0.000                    0.000                     0.002                       0.000
   100                  0.000                    0.000                     0.007                       0.000
  1000                  0.003                    0.000                     0.060                       0.000
 10000                  0.030                    0.000                     0.622                       0.000
100000                  0.442                    0.000                     7.830                       0.001
```

`CaseInsensitiveDictUpper` vs standard dict:
```
  Size    Dict Init Time (ms)    Dict Lookup Time (ms)    CI Dict Init Time (ms)    CI Dict Lookup Time (ms)
------  ---------------------  -----------------------  ------------------------  --------------------------
     1                  0.000                    0.000                     0.008                       0.001
    10                  0.000                    0.000                     0.003                       0.001
   100                  0.001                    0.000                     0.016                       0.000
  1000                  0.003                    0.000                     0.138                       0.000
 10000                  0.019                    0.000                     1.403                       0.001
100000                  0.511                    0.001                    16.021                       0.002
```

---

<details>

<summary> Test Script (by GPT) </summary>

```python
import time
import random
import string
from monty.collections import CaseInsensitiveDictUpper
from tabulate import tabulate


def measure_time_for_initialization(dict_type, size: int) -> float:
    """Measure time to initialize a dictionary of size `size`."""
    data = {random_string(): random.randint(1, 100) for _ in range(size)}
    start_time = time.perf_counter()
    dict_type(data)
    return (time.perf_counter() - start_time) * 1000  # Convert to milliseconds


def measure_time_for_lookup(dict_obj, size: int) -> float:
    """Measure time to look up a random key in the dictionary."""
    key = random.choice(list(dict_obj.keys()))
    start_time = time.perf_counter()
    dict_obj[key]
    return (time.perf_counter() - start_time) * 1000  # Convert to milliseconds


def random_string(length: int = 5) -> str:
    """Generate a random string of given length."""
    return ''.join(random.choices(string.ascii_lowercase, k=length))


def compare_performance():
    sizes = [1, 10, 100, 1000, 10_000, 100_000]
    results = []

    # Compare performance for standard dict and CaseInsensitiveDictUpper
    for size in sizes:
        # Initialize and measure performance for dict
        dict_init_time = measure_time_for_initialization(dict, size)
        dict_lookup_time = measure_time_for_lookup(dict({random_string(): random.randint(1, 100) for _ in range(size)}), size)

        # Initialize and measure performance for CaseInsensitiveDictUpper
        cid_init_time = measure_time_for_initialization(CaseInsensitiveDictUpper, size)
        cid_lookup_time = measure_time_for_lookup(CaseInsensitiveDictUpper({random_string(): random.randint(1, 100) for _ in range(size)}), size)

        results.append([
            size,
            dict_init_time,
            dict_lookup_time,
            cid_init_time,
            cid_lookup_time,
        ])

    # Print the results in a table format
    headers = ["Size", "Dict Init Time (ms)", "Dict Lookup Time (ms)", "CI Dict Init Time (ms)", "CI Dict Lookup Time (ms)"]
    print(tabulate(results, headers=headers, floatfmt=".3f"))


if __name__ == "__main__":
    compare_performance()
```
</details>

