### PR TITLE
Fix `jsanitize` when `recursive_msonable=True`

### DIFF
--- a/monty/json.py
+++ b/monty/json.py
@@ -715,7 +715,13 @@ def jsanitize(
             pass
 
     if recursive_msonable and isinstance(obj, MSONable):
-        return obj.as_dict()
+        return jsanitize(
+            obj.as_dict(),
+            strict=strict,
+            allow_bson=allow_bson,
+            enum_values=enum_values,
+            recursive_msonable=recursive_msonable,
+        )
 
     if not strict:
         return str(obj)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -15,7 +15,7 @@ from bson.objectid import ObjectId
 
 from monty.json import MontyDecoder, MontyEncoder, MSONable, _load_redirect, jsanitize
 
-from . import __version__ as tests_version
+from monty import __version__ as tests_version
 
 test_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_files")
 
@@ -576,6 +576,18 @@ class TestJson:
         assert clean_recursive_msonable["hello"]["a"] == 1
         assert clean_recursive_msonable["hello"]["b"] == 2
 
+        DoubleGoodMSONClass = GoodMSONClass(1, 2, 3)
+        DoubleGoodMSONClass.values = [GoodMSONClass(1, 2, 3)]
+        clean_recursive_msonable = jsanitize(
+            DoubleGoodMSONClass, recursive_msonable=True
+        )
+        assert clean_recursive_msonable["a"] == 1
+        assert clean_recursive_msonable["b"] == 2
+        assert clean_recursive_msonable["c"] == 3
+        assert clean_recursive_msonable["values"][0]["a"] == 1
+        assert clean_recursive_msonable["values"][0]["b"] == 2
+        assert clean_recursive_msonable["values"][0]["c"] == 3
+        
         d = {"dt": datetime.datetime.now()}
         clean = jsanitize(d)
         assert isinstance(clean["dt"], str)


### PR DESCRIPTION
## Summary

Closes #726 by fixing the `jsanitize(recursive_msonable=True)` behavior.

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved sanitization process for MSONable objects, ensuring consistent handling of nested structures.

- **Tests**
	- Updated import for version information in the test suite.
	- Introduced a new test case to validate the `jsanitize` function with nested MSONable objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->