### PR TITLE
Fix `jsanitize` when `recursive_msonable=True`

### DIFF
--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -992,7 +992,13 @@ def jsanitize(
 
     if recursive_msonable:
         try:
-            return obj.as_dict()
+            return jsanitize(
+                obj.as_dict(),
+                strict=strict,
+                allow_bson=allow_bson,
+                enum_values=enum_values,
+                recursive_msonable=recursive_msonable,
+            )
         except AttributeError:
             pass
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -20,7 +20,7 @@ from monty.json import (
     load,
 )
 
-from . import __version__ as TESTS_VERSION
+from monty import __version__ as TESTS_VERSION
 
 try:
     import pandas as pd
@@ -794,6 +794,18 @@ class TestJson:
         assert clean_recursive_msonable["hello"][1] == "test"
         assert clean_recursive_msonable["test"] == "hi"
 
+        DoubleGoodMSONClass = GoodMSONClass(1, 2, 3)
+        DoubleGoodMSONClass.values = [GoodMSONClass(1, 2, 3)]
+        clean_recursive_msonable = jsanitize(
+            DoubleGoodMSONClass, recursive_msonable=True
+        )
+        assert clean_recursive_msonable["a"] == 1
+        assert clean_recursive_msonable["b"] == 2
+        assert clean_recursive_msonable["c"] == 3
+        assert clean_recursive_msonable["values"][0]["a"] == 1
+        assert clean_recursive_msonable["values"][0]["b"] == 2
+        assert clean_recursive_msonable["values"][0]["c"] == 3
+        
         d = {"dt": datetime.datetime.now()}
         clean = jsanitize(d)
         assert isinstance(clean["dt"], str)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -11,7 +11,7 @@ from typing import Union
 import numpy as np
 import pytest
 
-from monty import __version__ as TESTS_VERSION
+from . import __version__ as TESTS_VERSION
 from monty.json import (
     MontyDecoder,
     MontyEncoder,

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -11,7 +11,6 @@ from typing import Union
 import numpy as np
 import pytest
 
-from . import __version__ as TESTS_VERSION
 from monty.json import (
     MontyDecoder,
     MontyEncoder,
@@ -20,6 +19,8 @@ from monty.json import (
     jsanitize,
     load,
 )
+
+from . import __version__ as TESTS_VERSION
 
 try:
     import pandas as pd

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -11,6 +11,7 @@ from typing import Union
 import numpy as np
 import pytest
 
+from monty import __version__ as TESTS_VERSION
 from monty.json import (
     MontyDecoder,
     MontyEncoder,
@@ -19,8 +20,6 @@ from monty.json import (
     jsanitize,
     load,
 )
-
-from monty import __version__ as TESTS_VERSION
 
 try:
     import pandas as pd
@@ -805,7 +804,7 @@ class TestJson:
         assert clean_recursive_msonable["values"][0]["a"] == 1
         assert clean_recursive_msonable["values"][0]["b"] == 2
         assert clean_recursive_msonable["values"][0]["c"] == 3
-        
+
         d = {"dt": datetime.datetime.now()}
         clean = jsanitize(d)
         assert isinstance(clean["dt"], str)


### PR DESCRIPTION
## Summary

Closes #726 by fixing the `jsanitize(recursive_msonable=True)` behavior.

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `jsanitize` function to improve sanitization of MSONable objects, ensuring consistent and thorough data cleaning.
  
- **Tests**
	- Introduced a new test case for the `jsanitize` function to validate handling of nested MSONable objects, improving test coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->