### PR TITLE
Fix `collections.ControlledDict` handling of Iterators via `update` method, fix Python version in test workflow and recover Windows in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python }}
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        os: [ubuntu-latest, macos-14] #, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 20
       matrix:
         os: [ubuntu-latest, macos-14] #, windows-latest]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ maintainers = [
 ]
 description = "Monty is the missing complement to Python."
 readme = "README.md"
-requires-python = ">=3.10,<=3.13"
+requires-python = ">=3.10,<3.14"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ maintainers = [
 ]
 description = "Monty is the missing complement to Python."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<=3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 4 - Beta",

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -91,7 +91,7 @@ class ControlledDict(collections.UserDict, ABC):
         """Forbid adding or updating keys based on _allow_add and _allow_update."""
 
         updates = dict(*args, **kwargs)
-        for key in dict(*args, **kwargs):
+        for key in updates:
             if key not in self.data and not self._allow_add:
                 raise TypeError(
                     f"Cannot add new key {key!r} using update, because add is disabled."

--- a/src/monty/collections.py
+++ b/src/monty/collections.py
@@ -89,6 +89,8 @@ class ControlledDict(collections.UserDict, ABC):
 
     def update(self, *args, **kwargs) -> None:
         """Forbid adding or updating keys based on _allow_add and _allow_update."""
+
+        updates = dict(*args, **kwargs)
         for key in dict(*args, **kwargs):
             if key not in self.data and not self._allow_add:
                 raise TypeError(
@@ -99,7 +101,7 @@ class ControlledDict(collections.UserDict, ABC):
                     f"Cannot update key {key!r} using update, because update is disabled."
                 )
 
-        super().update(*args, **kwargs)
+        super().update(updates)
 
     def setdefault(self, key, default=None) -> Any:
         """Forbid adding or updating keys based on _allow_add and _allow_update.

--- a/src/monty/io.py
+++ b/src/monty/io.py
@@ -58,7 +58,7 @@ def zopen(
     # TODO: remove default value of `mode` to force user to give one after deadline
     if mode is None:
         warnings.warn(
-            "We strongly discourage using a default `mode`, it would be"
+            "We strongly discourage using a default `mode`, it would be "
             f"set to `r` now but would not be allowed after {_deadline}",
             FutureWarning,
             stacklevel=2,

--- a/src/monty/io.py
+++ b/src/monty/io.py
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
     from typing import IO, Any, Iterator, Union
 
 
+class EncodingWarning(Warning): ...  # Added in Python 3.10
+
+
 def zopen(
     filename: Union[str, Path],
     /,

--- a/src/monty/io.py
+++ b/src/monty/io.py
@@ -22,9 +22,6 @@ if TYPE_CHECKING:
     from typing import IO, Any, Iterator, Union
 
 
-class EncodingWarning(Warning): ...  # Added in Python 3.10
-
-
 def zopen(
     filename: Union[str, Path],
     /,

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -62,6 +62,10 @@ class TestControlledDict:
         dct.update({"a": 3})
         assert dct["a"] == 3
 
+        # Test Iterator handling
+        dct.update(zip(["c", "d"], [11, 12]))
+        assert dct["c"] == 11
+
         dct.setdefault("a", 4)  # existing key
         assert dct["a"] == 3
 
@@ -157,7 +161,11 @@ def test_namespace_dict():
     dct["hello"] = "world"
     assert dct["key"] == "val"
 
-    # Test update (not allowed)
+    # Test use `update` to add new values
+    dct.update({"new_key": "new_value"})
+    assert dct["new_key"] == "new_value"
+
+    # Test add (not allowed)
     with pytest.raises(TypeError, match="update is disabled"):
         dct["key"] = "val"
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -126,6 +126,11 @@ class TestControlledDict:
         assert not dct._allow_add
         assert not dct._allow_update
 
+    def test_iterator_handling(self):
+        """Make sure iterators are handling correctly."""
+        c_dict = ControlledDict(zip(["c", "d"], [11, 12]))
+        assert c_dict["c"] == 11
+
 
 def test_frozendict():
     dct = frozendict({"hello": "world"})

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import pytest
 
 from monty.io import (
-    EncodingWarning,
     FileLock,
     FileLockException,
     _get_line_ending,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -425,6 +425,7 @@ class TestZopen:
 
         # Cannot decompress a real LZW file
         with (
+            pytest.warns(FutureWarning, match="compress LZW-compressed files"),
             pytest.raises(gzip.BadGzipFile, match="Not a gzipped file"),
             zopen(f"{TEST_DIR}/real_lzw_file.txt.Z", "rt", encoding="utf-8") as f,
         ):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from monty.io import (
+    EncodingWarning,
     FileLock,
     FileLockException,
     _get_line_ending,


### PR DESCRIPTION
- Fix `collections.ControlledDict` handling of Iterators via `update` method, to fix https://github.com/materialsproject/pymatgen/pull/4223
- Add tests for Python 3.11 and 3.13 to maximize test coverage as `monty` test is pretty cheap, fix `python-version` in test workflow

