### PR TITLE
allow `strict="skip"` for `jsanitize`

### DIFF
--- a/src/monty/json.py
+++ b/src/monty/json.py
@@ -905,7 +905,8 @@ def jsanitize(
             jsanitize will try to get the as_dict() attribute of the object. If
             no such attribute is found, an attribute error will be thrown. If
             strict is False, jsanitize will simply call str(object) to convert
-            the object to a string representation.
+            the object to a string representation.  If "skip" is provided,
+            jsanitize will skip and return the original object without modification.
         allow_bson (bool): This parameter sets the behavior when jsanitize
             encounters a bson supported type such as objectid and datetime. If
             True, such bson types will be ignored, allowing for proper
@@ -1009,7 +1010,7 @@ def jsanitize(
         except AttributeError:
             pass
 
-    if not strict:
+    if strict is False:
         return str(obj)
 
     if isinstance(obj, str):
@@ -1024,13 +1025,18 @@ def jsanitize(
             recursive_msonable=recursive_msonable,
         )
 
-    return jsanitize(
-        obj.as_dict(),
-        strict=strict,
-        allow_bson=allow_bson,
-        enum_values=enum_values,
-        recursive_msonable=recursive_msonable,
-    )
+    try:
+        return jsanitize(
+            obj.as_dict(),
+            strict=strict,
+            allow_bson=allow_bson,
+            enum_values=enum_values,
+            recursive_msonable=recursive_msonable,
+        )
+    except Exception as exc_:
+        if strict == "skip":
+            return obj
+        raise exc_
 
 
 def _serialize_callable(o):


### PR DESCRIPTION
# Optional Alternative Behavior for `jsanitize`

Currently, if we use `strict=False` all of the unserializable objects will be replaced with the `str` representation which will lose information.  The situation I'm thinking of is the case of processing an object that is not necessarily top-level msonable but we still want to convert it to a dictionary first for processing with the `_get_partial_json` mechanism.

This PR adds a new way for `jsanitize` to behave:

If you provide `strict="skip"` it will just ignore any unserializable objects and leave it alone. without converting into a string.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced JSON sanitization function with more flexible error handling.
	- Added support for skipping unserializable objects during JSON processing.

- **Tests**
	- Introduced new test case for handling composite objects with mixed serialization capabilities.

- **Bug Fixes**
	- Improved handling of objects that cannot be easily serialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->