### PR TITLE
Re-add python 3.9 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 20
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ Monty is created to serve as a complement to the Python standard library. It
 provides suite of tools to solve many common problems, and hopefully,
 be a resource to collect the best solutions.
 
-Monty supports Python 3.10+.
+Monty supports Python 3.9+.
 
 Please visit the [official docs](https://materialsvirtuallab.github.io/monty) for more information.

--- a/pylintrc
+++ b/pylintrc
@@ -80,7 +80,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.10
+py-version=3.9
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ maintainers = [
 ]
 description = "Monty is the missing complement to Python."
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.9,<3.14"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 4 - Beta",
@@ -60,7 +60,7 @@ include = ["monty", "monty.*"]
 
 [tool.black]
 line-length = 120
-target-version = ["py310"]
+target-version = ["py39"]
 include = '\.pyi?$'
 exclude = '''
 (


### PR DESCRIPTION
## Summary

Re-add python 3.9 support, as the oversight in `dev.deprecated` warning seem to broadly impact downstream packages on Python 3.9 and would require hacky removal of `CI` environment variable 

Also `monty` doesn't really have too many Python version specific functionalities, supporting a broader Python version might bring other fixes to lower Python versions.

