### PR TITLE
Deprecate `copy_r` with builtin `shutil.copytree(src, dst, dirs_exist_ok=True)`

### DIFF
--- a/src/monty/io.py
+++ b/src/monty/io.py
@@ -47,7 +47,7 @@ def zopen(
             be set to UTF-8 by default otherwise.
 
     Args:
-        filename (str | Path): The file to open.
+        filename (PathLike): The file to open.
         mode (str): The mode in which the file is opened, you should
             explicitly specify "b" for binary or "t" for text.
         **kwargs: Additional keyword arguments to pass to `open`.
@@ -181,7 +181,7 @@ def reverse_readfile(
     of such a function).
 
     Args:
-        filename (str | Path): File to read.
+        filename (PathLike): File to read.
 
     Yields:
         Lines from the file in reverse order.

--- a/src/monty/os/path.py
+++ b/src/monty/os/path.py
@@ -5,7 +5,6 @@ Path based methods, e.g., which, zpath, etc.
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from monty.fnmatch import WildCard
@@ -14,8 +13,10 @@ from monty.string import list_strings
 if TYPE_CHECKING:
     from typing import Callable, Literal, Optional, Union
 
+    from monty.shutil import PathLike
 
-def zpath(filename: str | Path) -> str:
+
+def zpath(filename: PathLike) -> str:
     """
     Returns an existing (zipped or unzipped) file path given the unzipped
     version. If no path exists, returns the filename unmodified.

--- a/src/monty/shutil.py
+++ b/src/monty/shutil.py
@@ -7,23 +7,25 @@ import shutil
 import warnings
 from gzip import GzipFile
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from monty.io import zopen
 
 if TYPE_CHECKING:
-    from typing import Literal, Optional
+    from typing import Literal, Optional, TypeAlias
+
+PathLike: TypeAlias = Union[str, Path]
 
 
-def copy_r(src: str | Path, dst: str | Path) -> None:
+def copy_r(src: PathLike, dst: PathLike) -> None:
     """
     Implements a recursive copy function similar to Unix's "cp -r" command.
     Surprisingly, python does not have a real equivalent. shutil.copytree
     only works if the destination directory is not present.
 
     Args:
-        src (str | Path): Source folder to copy.
-        dst (str | Path): Destination folder.
+        src (PathLike): Source folder to copy.
+        dst (PathLike): Destination folder.
     """
     src = Path(src)
     dst = Path(dst)
@@ -42,7 +44,7 @@ def copy_r(src: str | Path, dst: str | Path) -> None:
             warnings.warn(f"Cannot copy {fpath} to itself")
 
 
-def gzip_dir(path: str | Path, compresslevel: int = 6) -> None:
+def gzip_dir(path: PathLike, compresslevel: int = 6) -> None:
     """
     Gzips all files in a directory. Note that this is different from
     shutil.make_archive, which creates a tar archive. The aim of this method
@@ -50,7 +52,7 @@ def gzip_dir(path: str | Path, compresslevel: int = 6) -> None:
     commands like zless or zcat.
 
     Args:
-        path (str | Path): Path to directory.
+        path (PathLike): Path to directory.
         compresslevel (int): Level of compression, 1-9. 9 is default for
             GzipFile, 6 is default for gzip.
     """
@@ -74,9 +76,9 @@ def gzip_dir(path: str | Path, compresslevel: int = 6) -> None:
 
 
 def compress_file(
-    filepath: str | Path,
+    filepath: PathLike,
     compression: Literal["gz", "bz2"] = "gz",
-    target_dir: Optional[str | Path] = None,
+    target_dir: Optional[PathLike] = None,
 ) -> None:
     """
     Compresses a file with the correct extension. Functions like standard
@@ -84,10 +86,10 @@ def compress_file(
     uncompressed files are not retained.
 
     Args:
-        filepath (str | Path): Path to file.
+        filepath (PathLike): Path to file.
         compression (str): A compression mode. Valid options are "gz" or
             "bz2". Defaults to "gz".
-        target_dir (str | Path): An optional target dir where the result compressed
+        target_dir (PathLike): An optional target dir where the result compressed
             file would be stored. Defaults to None for in-place compression.
     """
     filepath = Path(filepath)
@@ -99,7 +101,7 @@ def compress_file(
     if filepath.suffix.lower() != f".{compression}" and not filepath.is_symlink():
         if target_dir is not None:
             os.makedirs(target_dir, exist_ok=True)
-            compressed_file: str | Path = target_dir / f"{filepath.name}.{compression}"
+            compressed_file: PathLike = target_dir / f"{filepath.name}.{compression}"
 
         else:
             compressed_file = f"{str(filepath)}.{compression}"
@@ -110,14 +112,14 @@ def compress_file(
         os.remove(filepath)
 
 
-def compress_dir(path: str | Path, compression: Literal["gz", "bz2"] = "gz") -> None:
+def compress_dir(path: PathLike, compression: Literal["gz", "bz2"] = "gz") -> None:
     """
     Recursively compresses all files in a directory. Note that this
     compresses all files singly, i.e., it does not create a tar archive. For
     that, just use Python tarfile class.
 
     Args:
-        path (str | Path): Path to parent directory.
+        path (PathLike): Path to parent directory.
         compression (str): A compression mode. Valid options are "gz" or
             "bz2". Defaults to gz.
     """
@@ -130,15 +132,15 @@ def compress_dir(path: str | Path, compression: Literal["gz", "bz2"] = "gz") -> 
 
 
 def decompress_file(
-    filepath: str | Path, target_dir: Optional[str | Path] = None
+    filepath: PathLike, target_dir: Optional[PathLike] = None
 ) -> str | None:
     """
     Decompresses a file with the correct extension. Automatically detects
     gz, bz2 or z extension.
 
     Args:
-        filepath (str | Path): Path to file.
-        target_dir (str | Path): An optional target dir where the result decompressed
+        filepath (PathLike): Path to file.
+        target_dir (PathLike): An optional target dir where the result decompressed
             file would be stored. Defaults to None for in-place decompression.
 
     Returns:
@@ -151,7 +153,7 @@ def decompress_file(
     if file_ext.lower() in {".bz2", ".gz", ".z"} and filepath.is_file():
         if target_dir is not None:
             os.makedirs(target_dir, exist_ok=True)
-            decompressed_file: str | Path = target_dir / filepath.name.removesuffix(
+            decompressed_file: PathLike = target_dir / filepath.name.removesuffix(
                 file_ext
             )
         else:
@@ -166,12 +168,12 @@ def decompress_file(
     return None
 
 
-def decompress_dir(path: str | Path) -> None:
+def decompress_dir(path: PathLike) -> None:
     """
     Recursively decompresses all files in a directory.
 
     Args:
-        path (str | Path): Path to parent directory.
+        path (PathLike): Path to parent directory.
     """
     path = Path(path)
     for parent, _, files in os.walk(path):
@@ -179,7 +181,7 @@ def decompress_dir(path: str | Path) -> None:
             decompress_file(Path(parent, f))
 
 
-def remove(path: str | Path, follow_symlink: bool = False) -> None:
+def remove(path: PathLike, follow_symlink: bool = False) -> None:
     """
     Implements a remove function that will delete files, folder trees and
     symlink trees.
@@ -189,7 +191,7 @@ def remove(path: str | Path, follow_symlink: bool = False) -> None:
     3.) Remove directory with rmtree
 
     Args:
-        path (str | Path): path to remove
+        path (PathLike): path to remove
         follow_symlink(bool): follow symlinks and removes whatever is in them
     """
     path = Path(path)

--- a/src/monty/shutil.py
+++ b/src/monty/shutil.py
@@ -19,6 +19,8 @@ PathLike: TypeAlias = Union[str, Path]
 
 def copy_r(src: PathLike, dst: PathLike) -> None:
     """
+    Deprecated: please use `shutil.copytree(src, dst, dirs_exist_ok=True)`
+
     Implements a recursive copy function similar to Unix's "cp -r" command.
     Surprisingly, python does not have a real equivalent. shutil.copytree
     only works if the destination directory is not present.
@@ -27,21 +29,13 @@ def copy_r(src: PathLike, dst: PathLike) -> None:
         src (PathLike): Source folder to copy.
         dst (PathLike): Destination folder.
     """
-    src = Path(src)
-    dst = Path(dst)
-    abssrc = src.resolve()
-    absdst = dst.resolve()
-    os.makedirs(absdst, exist_ok=True)
-    for filepath in os.listdir(abssrc):
-        fpath = Path(abssrc, filepath)
-        if fpath.is_symlink():
-            continue
-        if fpath.is_file():
-            shutil.copy(fpath, absdst)
-        elif str(fpath) not in str(absdst):
-            copy_r(fpath, Path(absdst, filepath))
-        else:
-            warnings.warn(f"Cannot copy {fpath} to itself")
+    # TODO: remove after 2027-01-01
+    warnings.warn(
+        "please use `shutil.copytree(src, dst, dirs_exist_ok=True)`",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    shutil.copytree(src, dst, dirs_exist_ok=True)
 
 
 def gzip_dir(path: PathLike, compresslevel: int = 6) -> None:

--- a/src/monty/tempfile.py
+++ b/src/monty/tempfile.py
@@ -5,11 +5,12 @@ Temporary directory and file creation utilities.
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from monty.shutil import copy_r, gzip_dir, remove
+from monty.shutil import gzip_dir, remove
 
 if TYPE_CHECKING:
     from typing import Union
@@ -100,7 +101,7 @@ class ScratchDir:
             tempdir = tempfile.mkdtemp(dir=self.rootpath)
             self.tempdir = os.path.abspath(tempdir)
             if self.start_copy:
-                copy_r(self.cwd, tempdir)
+                shutil.copytree(self.cwd, tempdir, dirs_exist_ok=True)
             if self.create_symbolic_link:
                 os.symlink(tempdir, ScratchDir.SCR_LINK)
             os.chdir(tempdir)
@@ -117,7 +118,7 @@ class ScratchDir:
                     gzip_dir(self.tempdir)
 
                 # copy files over
-                copy_r(self.tempdir, self.cwd)
+                shutil.copytree(self.tempdir, self.cwd, dirs_exist_ok=True)
 
                 # Delete any files that are now gone
                 if self.delete_removed_files:

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -41,7 +41,8 @@ class TestCopyR:
             )
 
     def test_recursive_copy_and_compress(self):
-        copy_r(os.path.join(TEST_DIR, "cpr_src"), os.path.join(TEST_DIR, "cpr_dst"))
+        with pytest.warns(DeprecationWarning, match="shutil.copytree"):
+            copy_r(os.path.join(TEST_DIR, "cpr_src"), os.path.join(TEST_DIR, "cpr_dst"))
         assert os.path.exists(os.path.join(TEST_DIR, "cpr_dst", "test"))
         assert os.path.exists(os.path.join(TEST_DIR, "cpr_dst", "sub", "testr"))
 
@@ -58,7 +59,8 @@ class TestCopyR:
 
     def test_pathlib(self):
         test_path = Path(TEST_DIR)
-        copy_r(test_path / "cpr_src", test_path / "cpr_dst")
+        with pytest.warns(DeprecationWarning, match="shutil.copytree"):
+            copy_r(test_path / "cpr_src", test_path / "cpr_dst")
         assert (test_path / "cpr_dst" / "test").exists()
         assert (test_path / "cpr_dst" / "sub" / "testr").exists()
 


### PR DESCRIPTION
Deprecate `copy_r` with builtin `shutil.copytree(src, dst, dirs_exist_ok=True)`

https://docs.python.org/3/library/shutil.html#shutil.copytree
> Changed in version 3.8: Added the dirs_exist_ok parameter.

