### PR TITLE
feat(yaml): round-trip MSONable + TypeHandler types in dumpfn/loadfn

### DIFF
--- a/src/monty/serialization.py
+++ b/src/monty/serialization.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 import os
+import pathlib
 from typing import TYPE_CHECKING, Literal, TextIO, cast
 
 from ruamel.yaml import YAML
 
 from monty.io import zopen
-from monty.json import MontyDecoder, MontyEncoder
+from monty.json import MontyDecoder, MontyEncoder, MSONable
 from monty.msgpack import default, object_hook
 
 try:
@@ -28,6 +29,47 @@ _FILE_TYPE = Literal["json", "jsonl", "yaml", "mpk"]
 # A single ``YAML()`` instance is reusable across calls and avoids per-call
 # construction cost (the constructor walks ruamel.yaml resolver tables).
 _YAML = YAML()
+
+# Bridge the JSON ``TypeHandler`` plugin registry into ruamel.yaml so MSONable
+# subclasses and every registered handler type (numpy, pandas, pint, torch,
+# uuid, bson, user-registered) round-trip through ``dumpfn`` / ``loadfn`` the
+# same way they do via JSON. ruamel.yaml retains its native rendering for
+# types it already supports (datetime, set, OrderedDict, bytes, primitives).
+_MONTY_ENCODER = MontyEncoder()
+
+
+def _represent_via_monty(representer: Any, data: Any) -> Any:
+    """Encode ``data`` via :class:`MontyEncoder` and represent the result.
+
+    Used as a ruamel.yaml multi-representer for ``MSONable`` / ``PurePath``
+    and as the fallback for the ``None``-keyed dispatch slot (replacing
+    ``represent_undefined``). The encoder returns a JSON-compatible value —
+    typically a dict with ``@module``/``@class`` — which ruamel.yaml then
+    represents recursively, so nested non-native types route through the
+    same hook.
+    """
+    return representer.represent_data(_MONTY_ENCODER.default(data))
+
+
+_YAML.representer.add_multi_representer(MSONable, _represent_via_monty)
+# Paths would otherwise hit ruamel.yaml's default ``str(obj)`` fallback,
+# which is lossy on load. Route them through the PathHandler envelope.
+_YAML.representer.add_multi_representer(pathlib.PurePath, _represent_via_monty)
+# Replace the ``None`` slot — invoked when neither yaml_representers nor
+# yaml_multi_representers match — with a hook that tries MontyEncoder first,
+# falling back to the original ``represent_undefined`` (which raises
+# ``RepresenterError``) if MontyEncoder cannot serialize the object either.
+_ORIG_REPRESENT_UNDEFINED = _YAML.representer.yaml_representers[None]
+
+
+def _represent_undefined(representer: Any, data: Any) -> Any:
+    try:
+        return _represent_via_monty(representer, data)
+    except TypeError:
+        return _ORIG_REPRESENT_UNDEFINED(representer, data)
+
+
+_YAML.representer.yaml_representers[None] = _represent_undefined
 
 
 def _identify_format(file_name: str | Path) -> _FILE_TYPE:
@@ -96,7 +138,15 @@ def loadfn(
             if fmt == "yaml":
                 if YAML is None:
                     raise RuntimeError("Loading of YAML files requires ruamel.yaml.")
-                return _YAML.load(fp, *args, **kwargs)
+                # ``cls`` is a monty-level kwarg (not ruamel.yaml's) — pop it
+                # before forwarding so ``_YAML.load`` doesn't choke. Passing
+                # ``cls=None`` opts out of MSONable reconstruction, matching
+                # the JSON path's escape hatch.
+                cls = kwargs.pop("cls", MontyDecoder)
+                loaded = _YAML.load(fp, *args, **kwargs)
+                if cls is not None:
+                    loaded = MontyDecoder().process_decoded(loaded)
+                return loaded
 
             if fmt in {"json", "jsonl"}:
                 if "cls" not in kwargs:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import datetime
 import glob
 import json
 import os
+import pathlib
 
+import numpy as np
 import pytest
 
-from monty.json import MSONable
+from monty.json import MSONable, TypeHandler, register, unregister
 from monty.serialization import dumpfn, loadfn
 from monty.tempfile import ScratchDir
 
@@ -114,3 +117,94 @@ class TestSerial:
             and toyMsonable.from_dict(entry["obj"]) == d[i]["obj"]
             for i, entry in enumerate(new_d)
         )
+
+    def test_yaml_msonable_roundtrip(self, tmp_dir):
+        """MSONable subclasses round-trip through YAML (issue #587)."""
+        obj = toyMsonable(a=7, b="seven")
+        dumpfn(obj, "monte_test.yaml")
+        reloaded = loadfn("monte_test.yaml")
+        assert isinstance(reloaded, toyMsonable)
+        assert reloaded == obj
+
+        # Nested inside list and dict.
+        nested = {"items": [toyMsonable(a=i, b=str(i)) for i in range(3)]}
+        dumpfn(nested, "monte_test.yaml")
+        reloaded = loadfn("monte_test.yaml")
+        assert all(isinstance(o, toyMsonable) for o in reloaded["items"])
+        assert reloaded["items"] == nested["items"]
+
+        # ``cls=None`` opts out of reconstruction, mirroring the JSON path.
+        raw = loadfn("monte_test.yaml", cls=None)
+        assert isinstance(raw["items"][0], dict)
+        assert raw["items"][0]["@class"] == "toyMsonable"
+
+    def test_yaml_numpy_path_roundtrip(self, tmp_dir):
+        """numpy arrays and pathlib paths round-trip through YAML."""
+        payload = {
+            "arr": np.array([1.0, 2.0, 3.0]),
+            "p": pathlib.Path("/tmp/example"),
+        }
+        dumpfn(payload, "monte_test.yaml")
+        reloaded = loadfn("monte_test.yaml")
+        assert isinstance(reloaded["arr"], np.ndarray)
+        np.testing.assert_array_equal(reloaded["arr"], payload["arr"])
+        assert isinstance(reloaded["p"], pathlib.PurePath)
+        assert reloaded["p"] == payload["p"]
+
+    def test_yaml_preserves_native_datetime(self, tmp_dir):
+        """datetime keeps ruamel.yaml's native rendering (no @module envelope)."""
+        when = datetime.datetime(2026, 5, 18, 12, 0, 0)
+        dumpfn({"when": when}, "monte_test.yaml")
+        with open("monte_test.yaml", encoding="utf-8") as f:
+            raw = f.read()
+        # Native ruamel.yaml emits the timestamp as a bare scalar, not as a
+        # ``@module``/``@class`` envelope.
+        assert "@module" not in raw
+        assert "2026-05-18" in raw
+        reloaded = loadfn("monte_test.yaml")
+        assert reloaded["when"] == when
+
+    def test_yaml_plain_dict_unchanged(self, tmp_dir):
+        """Plain dict YAML output is byte-identical to pre-#587 behavior."""
+        dumpfn({"hello": "world"}, "monte_test.yaml")
+        with open("monte_test.yaml", encoding="utf-8") as f:
+            raw = f.read()
+        assert raw == "hello: world\n"
+
+    def test_yaml_user_typehandler(self, tmp_dir):
+        """User-registered TypeHandlers participate in YAML round-trip."""
+
+        class MyType:
+            def __init__(self, value: int):
+                self.value = value
+
+            def __eq__(self, other):
+                return isinstance(other, MyType) and self.value == other.value
+
+        class MyHandler(TypeHandler):
+            module = "tests.test_serialization"
+            class_name = "MyType"
+
+            def matches(self, obj):
+                return isinstance(obj, MyType)
+
+            def encode(self, obj):
+                return {
+                    "@module": self.module,
+                    "@class": self.class_name,
+                    "value": obj.value,
+                }
+
+            def decode(self, d):
+                return MyType(d["value"])
+
+        handler = MyHandler()
+        register(handler)
+        try:
+            obj = MyType(42)
+            dumpfn(obj, "monte_test.yaml")
+            reloaded = loadfn("monte_test.yaml")
+            assert isinstance(reloaded, MyType)
+            assert reloaded == obj
+        finally:
+            unregister(handler)


### PR DESCRIPTION
## Summary

Closes #587. Brings JSON/YAML symmetry to `dumpfn`/`loadfn`: MSONable subclasses (e.g. the issue reporter's pyEQL `Solution`) and every type covered by a registered `TypeHandler` (numpy, pandas, pint, torch, uuid, pathlib, bson, user-registered) now round-trip through `.yaml` the same way they do via JSON.

- **Dump**: at module import in `src/monty/serialization.py`, register an `MSONable` multi-representer, a `pathlib.PurePath` multi-representer, and replace ruamel.yaml's `None`-slot fallback (`represent_undefined`) with a hook that routes through `MontyEncoder.default`. ruamel.yaml's native rendering is preserved for types it already handles well (datetime, set, OrderedDict, bytes, primitives) — only types it cannot represent natively flow through the `@module`/`@class` envelope.
- **Load**: wrap the `_YAML.load` result in `MontyDecoder().process_decoded`, with a `cls=None` opt-out that mirrors the JSON path's escape hatch.
- **No regressions**: plain-dict YAML output is byte-identical (asserted by `test_yaml_plain_dict_unchanged`); existing `test_dumpfn_loadfn` still passes.
- **No `TypeHandler` API change**: dispatch goes through the existing predicate-based registry via `represent_undefined`, so user-registered handlers participate automatically.

## Test plan
- [x] `uv run pytest tests/test_serialization.py -v` — 7 passed (1 msgpack skip). Five new tests cover MSONable (nested), numpy, pathlib.Path, native datetime preservation (raw-file check for absence of `@module`), plain-dict byte-identity, and a user-registered `TypeHandler` round-trip.
- [x] `uv run pytest tests/` — 236 passed, 13 skipped (optional deps), no regressions.
- [x] `uv run ruff check` + `uv run ruff format --check` — clean.
- [x] Manual smoke against the reporter's case (toy `MSONable` subclass round-trips through `.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)