### PR TITLE
fix(yaml): use thread-local YAML instance to fix concurrent loadfn/dumpfn (closes #795)

### DIFF
--- a/src/monty/serialization.py
+++ b/src/monty/serialization.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import threading
 from typing import TYPE_CHECKING, Literal, TextIO, cast
 
 from ruamel.yaml import YAML
@@ -25,10 +26,6 @@ if TYPE_CHECKING:
     from monty.shutil import PathLike
 
 _FILE_TYPE = Literal["json", "jsonl", "yaml", "mpk"]
-
-# A single ``YAML()`` instance is reusable across calls and avoids per-call
-# construction cost (the constructor walks ruamel.yaml resolver tables).
-_YAML = YAML()
 
 # Bridge the JSON ``TypeHandler`` plugin registry into ruamel.yaml so MSONable
 # subclasses and every registered handler type (numpy, pandas, pint, torch,
@@ -51,25 +48,45 @@ def _represent_via_monty(representer: Any, data: Any) -> Any:
     return representer.represent_data(_MONTY_ENCODER.default(data))
 
 
-_YAML.representer.add_multi_representer(MSONable, _represent_via_monty)
-# Paths would otherwise hit ruamel.yaml's default ``str(obj)`` fallback,
-# which is lossy on load. Route them through the PathHandler envelope.
-_YAML.representer.add_multi_representer(pathlib.PurePath, _represent_via_monty)
-# Replace the ``None`` slot — invoked when neither yaml_representers nor
-# yaml_multi_representers match — with a hook that tries MontyEncoder first,
-# falling back to the original ``represent_undefined`` (which raises
-# ``RepresenterError``) if MontyEncoder cannot serialize the object either.
-_ORIG_REPRESENT_UNDEFINED = _YAML.representer.yaml_representers[None]
+# ruamel.yaml's ``YAML`` instance holds mutable per-call state (parser,
+# composer, constructor, emitter, serializer, representer caches) bound to the
+# instance during ``load``/``dump``. Sharing a single instance across threads
+# races on that state — see issue #795. We instead keep one instance per
+# thread via ``threading.local``, which amortizes construction within a thread
+# while keeping concurrent threads independent.
+_yaml_local = threading.local()
 
 
-def _represent_undefined(representer: Any, data: Any) -> Any:
-    try:
-        return _represent_via_monty(representer, data)
-    except TypeError:
-        return _ORIG_REPRESENT_UNDEFINED(representer, data)
+def _build_yaml() -> YAML:
+    """Construct a YAML instance with monty's MSONable/PurePath representers."""
+    yaml = YAML()
+    yaml.representer.add_multi_representer(MSONable, _represent_via_monty)
+    # Paths would otherwise hit ruamel.yaml's default ``str(obj)`` fallback,
+    # which is lossy on load. Route them through the PathHandler envelope.
+    yaml.representer.add_multi_representer(pathlib.PurePath, _represent_via_monty)
+    # Replace the ``None`` slot — invoked when neither yaml_representers nor
+    # yaml_multi_representers match — with a hook that tries MontyEncoder first,
+    # falling back to the original ``represent_undefined`` (which raises
+    # ``RepresenterError``) if MontyEncoder cannot serialize the object either.
+    orig_represent_undefined = yaml.representer.yaml_representers[None]
+
+    def _represent_undefined(representer: Any, data: Any) -> Any:
+        try:
+            return _represent_via_monty(representer, data)
+        except TypeError:
+            return orig_represent_undefined(representer, data)
+
+    yaml.representer.yaml_representers[None] = _represent_undefined
+    return yaml
 
 
-_YAML.representer.yaml_representers[None] = _represent_undefined
+def _get_yaml() -> YAML:
+    """Return the calling thread's YAML instance, constructing it on first use."""
+    yaml = getattr(_yaml_local, "yaml", None)
+    if yaml is None:
+        yaml = _build_yaml()
+        _yaml_local.yaml = yaml
+    return yaml
 
 
 def _identify_format(file_name: str | Path) -> _FILE_TYPE:
@@ -139,11 +156,11 @@ def loadfn(
                 if YAML is None:
                     raise RuntimeError("Loading of YAML files requires ruamel.yaml.")
                 # ``cls`` is a monty-level kwarg (not ruamel.yaml's) — pop it
-                # before forwarding so ``_YAML.load`` doesn't choke. Passing
+                # before forwarding so ``YAML.load`` doesn't choke. Passing
                 # ``cls=None`` opts out of MSONable reconstruction, matching
                 # the JSON path's escape hatch.
                 cls = kwargs.pop("cls", MontyDecoder)
-                loaded = _YAML.load(fp, *args, **kwargs)
+                loaded = _get_yaml().load(fp, *args, **kwargs)
                 if cls is not None:
                     loaded = MontyDecoder().process_decoded(loaded)
                 return loaded
@@ -201,7 +218,7 @@ def dumpfn(
             if fmt == "yaml":
                 if YAML is None:
                     raise RuntimeError("Loading of YAML files requires ruamel.yaml.")
-                _YAML.dump(obj, fp, *args, **kwargs)
+                _get_yaml().dump(obj, fp, *args, **kwargs)
             elif fmt in {"json", "jsonl"}:
                 if "cls" not in kwargs:
                     kwargs["cls"] = MontyEncoder

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -171,6 +171,31 @@ class TestSerial:
             raw = f.read()
         assert raw == "hello: world\n"
 
+    def test_yaml_thread_safe_roundtrip(self, tmp_dir):
+        """Concurrent dumpfn/loadfn from threads do not corrupt YAML state (issue #795)."""
+        import concurrent.futures
+
+        def worker(idx: int) -> dict:
+            fn = f"monte_test_{idx}.yaml"
+            payload = {
+                "obj": toyMsonable(a=idx, b=str(idx)),
+                "arr": np.array([float(idx), float(idx) + 1.0]),
+                "p": pathlib.Path(f"/tmp/{idx}"),
+            }
+            dumpfn(payload, fn)
+            return loadfn(fn)
+
+        n = 32
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as ex:
+            results = list(ex.map(worker, range(n)))
+
+        for idx, result in enumerate(results):
+            assert isinstance(result["obj"], toyMsonable)
+            assert result["obj"].a == idx
+            assert result["obj"].b == str(idx)
+            np.testing.assert_array_equal(result["arr"], [float(idx), float(idx) + 1.0])
+            assert result["p"] == pathlib.Path(f"/tmp/{idx}")
+
     def test_yaml_user_typehandler(self, tmp_dir):
         """User-registered TypeHandlers participate in YAML round-trip."""
 


### PR DESCRIPTION
## Summary

- The module-level `_YAML = YAML()` in `monty.serialization` is shared across threads, but ruamel.yaml binds per-call parser / composer / constructor / emitter / serializer / representer caches to the instance during `load` / `dump`. Concurrent `loadfn` / `dumpfn` calls from multiple threads race on that state (issue #795, reported by @Andrew-S-Rosen).
- Replace the singleton with a thread-local factory: each thread builds and caches its own `YAML` instance with monty's `MSONable` / `PurePath` representers attached. Construction is still amortized within a thread; concurrent threads no longer share mutable state.
- Add a regression test that runs 32 dump/load round-trips across 8 worker threads, mixing `MSONable`, `numpy.ndarray`, and `pathlib.Path` payloads.

## Test plan

- [x] `uv run pytest tests/test_serialization.py` — 8 passed, 1 skipped
- [x] `uv run pytest tests/` — 229 passed, 12 skipped
- [x] `uv run ruff check src/monty/serialization.py tests/test_serialization.py`
- [x] `uv run ruff format --check src/monty/serialization.py tests/test_serialization.py`

Closes #795.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)