### PR TITLE
docs: fix broken README badges and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![GitHub license](https://img.shields.io/github/license/materialsvirtuallab/monty)](https://github.com/materialsvirtuallab/monty/blob/main/LICENSE)
-[![Linting](https://github.com/materialsvirtuallab/monty/workflows/Linting/badge.svg)](https://github.com/materialsvirtuallab/monty/workflows/Linting/badge.svg)
-[![Testing](https://github.com/materialsvirtuallab/monty/workflows/Testing/badge.svg)](https://github.com/materialsvirtuallab/monty/workflows/Testing/badge.svg)
+[![GitHub license](https://img.shields.io/github/license/materialyzeai/monty)](https://github.com/materialyzeai/monty/blob/master/LICENSE.rst)
+[![Lint](https://github.com/materialyzeai/monty/actions/workflows/lint.yml/badge.svg)](https://github.com/materialyzeai/monty/actions/workflows/lint.yml)
+[![Test](https://github.com/materialyzeai/monty/actions/workflows/test.yml/badge.svg)](https://github.com/materialyzeai/monty/actions/workflows/test.yml)
 [![Downloads](https://static.pepy.tech/badge/monty)](https://pepy.tech/project/monty)
-[![codecov](https://codecov.io/gh/materialsvirtuallab/monty/branch/master/graph/badge.svg?token=QdfT2itxgu)](https://codecov.io/gh/materialsvirtuallab/monty)
+[![codecov](https://codecov.io/gh/materialyzeai/monty/branch/master/graph/badge.svg)](https://codecov.io/gh/materialyzeai/monty)
 
 # Monty: Python Made Even Easier
 
@@ -26,4 +26,4 @@ be a resource to collect the best solutions.
 
 Monty supports Python 3.9+.
 
-Please visit the [official docs](https://materialsvirtuallab.github.io/monty) for more information.
+Please visit the [official docs](https://materialyzeai.github.io/monty) for more information.


### PR DESCRIPTION
## Summary

All five README badges were pointing at the stale `materialsvirtuallab` org and the wrong branch/workflow names, so they rendered broken on the repo's GitHub front page.

- Repoint license, workflow, codecov, and docs URLs from `materialsvirtuallab/monty` (main) to `materialyzeai/monty` (master).
- Switch workflow badges from the deprecated `/workflows/<Name>/badge.svg` form to `/actions/workflows/<file>.yml/badge.svg`, and rename `Linting` / `Testing` to `Lint` / `Test` to match the current workflow names in `.github/workflows/`.
- Link each workflow badge to its run page instead of to its own badge SVG.
- Drop the stale codecov token query string (public repo doesn't need one) and fix the license link to `LICENSE.rst`.
- Repoint the "official docs" link to `materialyzeai.github.io/monty` (old URL 404s).

## Test plan

- [x] `curl -sI` on every badge / link URL returns 200